### PR TITLE
fix file space bug in batch_downloader.py

### DIFF
--- a/utils/features/downloader/batch_downloader.py
+++ b/utils/features/downloader/batch_downloader.py
@@ -349,7 +349,11 @@ class E6_Downloader:
             help.verbose_print(f"db_export_file_path:\t{db_export_file_path}")
 
             if shutil.which('curl') is not None:
-                subprocess.check_output(f'curl https://e621.net/db_export/ -o {db_export_file_path}', shell=True)
+                prev_dir = os.getcwd()
+                os.chdir(base_folder)
+                cmd = 'curl https://e621.net/db_export/ -o db_export.html'  
+                subprocess.check_output(cmd, shell=True)
+                os.chdir(prev_dir)
             with open(db_export_file_path) as f:
                 contents = f.read()
 


### PR DESCRIPTION
with the old method of running curl, the command would error out if the file you were trying to write to had a space in it. this new method uses os.chdir() to set the working directory to the file instead, fixing the issue