### PR TITLE
Fix delimiter naming across helper functions and UI

### DIFF
--- a/UI_tabs/download_tab.py
+++ b/UI_tabs/download_tab.py
@@ -990,7 +990,7 @@ class Download_tab:
                             self.settings_json["proxy_url"] = proxy_value
                         proxy_url_textbox = gr.Textbox(lines=1, label='(Optional Proxy URL)', value=self.settings_json["proxy_url"])
                     with gr.Column(min_width=50, scale=1):
-                        tag_sep = gr.Textbox(lines=1, label='Tag Separator/Delimeter', value=self.settings_json["tag_sep"])
+                        tag_sep = gr.Textbox(lines=1, label='Tag Separator/Delimiter', value=self.settings_json["tag_sep"])
                     with gr.Column(min_width=50, scale=5):
                         tag_order_format = gr.Dropdown(multiselect=True, interactive=True, label='Tag ORDER',
                                                        choices=self.image_board.valid_categories,

--- a/utils/features/downloader/batch_downloader.py
+++ b/utils/features/downloader/batch_downloader.py
@@ -697,7 +697,7 @@ class E6_Downloader:
                 help.verbose_print(f"sublist:\t{sublist}")
                 parts = (sublist[1].replace('dir=', '')).split('\\')
                 parts = [subpart for part in parts for subpart in part.split('/')]
-                new_path = f'{help.get_OS_delimeter()}'.join(parts)
+                new_path = f'{help.get_OS_delimiter()}'.join(parts)
                 url = sublist[0]
                 new_path = os.path.join(new_path, image_id_w_ext)
                 help.verbose_print(f"new_path:\t{new_path}")

--- a/utils/helper_functions.py
+++ b/utils/helper_functions.py
@@ -108,11 +108,11 @@ def execute(cmd):
     if return_code:
         raise sub.CalledProcessError(return_code, cmd)
 
-def get_list(arb_string, delimeter):
-    return arb_string.split(delimeter)
+def get_list(arb_string, delimiter):
+    return arb_string.split(delimiter)
 
-def get_string(arb_list, delimeter):
-    return delimeter.join(arb_list)
+def get_string(arb_list, delimiter):
+    return delimiter.join(arb_list)
 
 def from_padded(line):
     if len(line) > 1:# check for padded-0
@@ -126,7 +126,7 @@ def to_padded(num):
 def is_windows():
     return os.name == 'nt'
 
-def get_OS_delimeter():
+def get_OS_delimiter():
     """Return the path delimiter for the current operating system."""
     if is_windows():
         return '\\'


### PR DESCRIPTION
## Summary
- fix typo: use `delimiter` in helper functions and OS delimiter helper
- update downloader batch file to call renamed helper
- update UI label for tag separator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685204f18be48321816284611f3a3b9e