### PR TITLE
Add tests for helper functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 !UI_tabs/
 !utils/
 !wiki_assets/
+!tests/
 
 # Whitelist the specific files
 !LICENSE

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ onnxruntime
 torch
 onnxruntime-gpu
 piexif
+pytest

--- a/tests/test_helper_functions.py
+++ b/tests/test_helper_functions.py
@@ -1,0 +1,23 @@
+import utils.helper_functions as hf
+
+
+def test_get_os_delimiter_windows(monkeypatch):
+    monkeypatch.setattr(hf.os, 'name', 'nt')
+    assert hf.get_OS_delimeter() == '\\'
+
+
+def test_get_os_delimiter_non_windows(monkeypatch):
+    monkeypatch.setattr(hf.os, 'name', 'posix')
+    assert hf.get_OS_delimeter() == '/'
+
+
+def test_from_padded_removes_leading_zero():
+    assert hf.from_padded('05') == 5
+
+
+def test_from_padded_returns_int_when_unpadded():
+    assert hf.from_padded('12') == 12
+
+
+def test_from_padded_single_digit():
+    assert hf.from_padded('7') == 7


### PR DESCRIPTION
## Summary
- add test suite for helper functions
- include pytest in requirements
- allow tests directory in repo by updating `.gitignore`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685204ff1710832194e93e77e37c5566