### PR TITLE
Fix downloader utility and add file selection improvements

### DIFF
--- a/utils/helper_functions.py
+++ b/utils/helper_functions.py
@@ -89,6 +89,10 @@ def update_JSON(settings, temp_config_name):
     temp = copy.deepcopy(settings)
     for entry in temp:
         verbose_print(f"{entry}:\t{settings[entry]}")
+    # Ensure the target directory exists before writing the JSON file
+    dir_name = os.path.dirname(temp_config_name)
+    if dir_name:
+        os.makedirs(dir_name, exist_ok=True)
 
     with open(temp_config_name, "w") as f:
         json.dump(temp, indent=4, fp=f)
@@ -132,6 +136,11 @@ def get_OS_delimiter():
         return '\\'
     else:
         return '/'
+
+# Backwards compatibility for legacy code/tests using the misspelled
+# function name ``get_OS_delimeter``.
+def get_OS_delimeter():
+    return get_OS_delimiter()
 
 def unzip_file(file_path, new_name=""):
     temp = '\\' if is_windows() else '/'

--- a/webui.py
+++ b/webui.py
@@ -43,7 +43,7 @@ def build_ui():
         download_checkboxes = ["skip_post_download", "reorder_tags", "replace_underscores", "remove_parentheses",
                                "do_sort"]
         resize_checkboxes = ["skip_resize", "delete_original"]
-        file_extn_list = ["png", "jpg", "gif"]
+        file_extn_list = ["images", "videos"]
 
         artist_csv_dict = {} ##################### eventually this will get migrated to the image_board_manager class!!!
         character_csv_dict = {} ##################### eventually this will get migrated to the image_board_manager class!!!
@@ -100,7 +100,7 @@ def build_ui():
 
         all_images_dict = {}  ### add images by key:id, value:selected_image_dict
         # load if data present / create if file not yet created
-        auto_config_path = os.path.join(cwd, "auto_configs")
+        auto_config_path = os.path.join(settings_json["batch_folder"], "configs")
         auto_complete_config_name = f"auto_complete_{settings_json['batch_folder']}.json"
         temp_config_path = os.path.join(auto_config_path, auto_complete_config_name)
         if not os.path.exists(auto_config_path):
@@ -236,7 +236,7 @@ def build_ui():
 
         ########################################################################################################
         # database tab init
-        database_tab_manager = Database_tab(db_manager)
+        database_tab_manager = Database_tab(db_manager, gallery_tab_manager)
         import_tab_manager = Import_tab(db_manager)
         merge_tab_manager = Merge_tab(db_manager)
         # render tabs


### PR DESCRIPTION
## Summary
- add `get_OS_delimeter` alias to avoid AttributeError
- ensure JSON configs create parent directories automatically
- add directory/file pickers in download tab and hook up events
- load configs from chosen JSON files
- show counts when viewing or searching database tables
- improve progress bars and add gallery integration from database searches
- enable image or video gallery modes and load images via PIL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854526bddcc8321a35845c6ac4f630a