### PR TITLE
Fix config path creation

### DIFF
--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -24,3 +24,12 @@ def test_search_files(tmp_path):
     assert rows and rows[0][headers.index('post_tags')].startswith('tag1')
     db.close()
 
+def test_get_latest_config(tmp_path):
+    db = setup_db(tmp_path)
+    assert db.get_latest_config() is None
+    cfg = {"a": 1}
+    db.add_config(cfg)
+    loaded = db.get_latest_config()
+    assert loaded == cfg
+    db.close()
+

--- a/utils/database.py
+++ b/utils/database.py
@@ -205,6 +205,20 @@ class DatabaseManager:
             rows = cur.fetchall()
             return rows
 
+    def get_latest_config(self):
+        """Return the most recently added config as a dictionary or None."""
+        with self.lock:
+            cur = self.conn.cursor()
+            cur.execute("SELECT json FROM configs ORDER BY id DESC LIMIT 1")
+            row = cur.fetchone()
+            cur.close()
+        if row and row[0]:
+            try:
+                return json.loads(row[0])
+            except Exception:
+                return None
+        return None
+
     def _compute_hash(self, file_path):
         """Return SHA1 hash for the given file."""
         h = hashlib.sha1()

--- a/utils/helper_functions.py
+++ b/utils/helper_functions.py
@@ -36,6 +36,9 @@ def load_session_config(f_name):
     session_config = None
     file_exists = os.path.exists(f_name)
     if not file_exists: # create the file
+        dir_name = os.path.dirname(f_name)
+        if dir_name:
+            os.makedirs(dir_name, exist_ok=True)
         with open(f_name, 'w') as f:
             f.close()
     else: # load the file

--- a/webui.py
+++ b/webui.py
@@ -61,7 +61,12 @@ def build_ui():
         selected_image_dict = None  ### key:category, value:tag_list  # set on every click ::  # id -> {categories: tag/s}, type -> string
         is_csv_loaded = False
         config_name = "settings.json"
-        settings_json = help.load_session_config(os.path.join(cwd, config_name))
+        config_path = os.path.join(cwd, config_name)
+        settings_json = db_manager.get_latest_config()
+        if not settings_json:
+            settings_json = help.load_session_config(config_path)
+            if settings_json:
+                db_manager.add_config(settings_json, config_path)
         # Register the default website configuration
         website_id = db_manager.add_website("e621")
 
@@ -101,7 +106,8 @@ def build_ui():
         all_images_dict = {}  ### add images by key:id, value:selected_image_dict
         # load if data present / create if file not yet created
         auto_config_path = os.path.join(settings_json["batch_folder"], "configs")
-        auto_complete_config_name = f"auto_complete_{settings_json['batch_folder']}.json"
+        batch_name = os.path.basename(settings_json["batch_folder"])
+        auto_complete_config_name = f"auto_complete_{batch_name}.json"
         temp_config_path = os.path.join(auto_config_path, auto_complete_config_name)
         if not os.path.exists(auto_config_path):
             os.makedirs(auto_config_path)


### PR DESCRIPTION
## Summary
- ensure directories exist in `load_session_config`
- generate a valid file name for auto-complete settings in `webui.py`
- pull configuration from the database when available and save default settings to the DB
- expose `DatabaseManager.get_latest_config`
- test new database functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685483c76cfc8321946f2c7542430fe6