### PR TITLE
Update progress tracking and config selection

### DIFF
--- a/utils/database.py
+++ b/utils/database.py
@@ -219,6 +219,21 @@ class DatabaseManager:
                 return None
         return None
 
+    def list_config_options(self):
+        """Return dropdown options and mapping from name to path for configs."""
+        with self.lock:
+            cur = self.conn.cursor()
+            cur.execute("SELECT id, path FROM configs ORDER BY id")
+            rows = cur.fetchall()
+            cur.close()
+        options = []
+        mapping = {}
+        for cid, path in rows:
+            name = os.path.basename(path) if path else f"config_{cid}.json"
+            options.append(name)
+            mapping[name] = path
+        return options, mapping
+
     def _compute_hash(self, file_path):
         """Return SHA1 hash for the given file."""
         h = hashlib.sha1()


### PR DESCRIPTION
## Summary
- add `list_config_options` helper to DatabaseManager
- track per-file progress in downloader and skip existing files
- read config dropdown options from database
- allow custom values for tag suggestion dropdowns
- ensure download process cleans up on completion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68549e48827c8321a0e9802cc06bb953