### PR TITLE
Update DB modification logging and config refresh

### DIFF
--- a/UI_tabs/database_tab.py
+++ b/UI_tabs/database_tab.py
@@ -91,11 +91,12 @@ class Database_tab:
         return gr.update(value=f"Copied {count} files")
 
     def send_table_to_gallery(self, table_name):
+        """Load the entire table into the gallery."""
         if not table_name:
             return gr.update(), gr.update(value="No table selected")
         if not self.gallery_tab_manager:
             return gr.update(), gr.update(value="Gallery not available")
-        headers, rows = self.db_manager.fetch_table(table_name)
+        headers, rows = self.db_manager.fetch_table(table_name, limit=None)
         images = self.gallery_tab_manager.load_from_db_rows(headers, rows)
         msg = f"Loaded {len(rows)} rows into gallery"
         return gr.update(value=images, visible=True), gr.update(value=msg)
@@ -152,7 +153,7 @@ class Database_tab:
                 create_table_btn = gr.Button(value="Create Table from Search")
                 export_dir = gr.Textbox(label="Export Directory")
                 export_button = gr.Button(value="Export Table Files")
-                send_search_btn = gr.Button(value="Load Search in Gallery")
+                send_search_btn = gr.Button(value="Load Searched Data in Gallery")
             with gr.Row():
                 send_table_btn = gr.Button(value="Load Table in Gallery")
 

--- a/UI_tabs/download_tab.py
+++ b/UI_tabs/download_tab.py
@@ -380,6 +380,20 @@ class Download_tab:
             self.auto_complete_config = {'png': {}, 'jpg': {}, 'gif': {}}
             help.update_JSON(self.auto_complete_config, temp_config_path)
 
+    def refresh_json_options(self):
+        """Refresh config dropdown choices from the database or disk."""
+        if self.db_manager:
+            batch_names, mapping = self.db_manager.list_config_options()
+            self.batch_to_json_map = mapping
+        else:
+            temp = '\\' if help.is_windows() else '/'
+            config_dir = os.path.join(self.settings_json["batch_folder"], "configs")
+            json_names_full_paths = glob.glob(os.path.join(config_dir, f"*.json"))
+            json_names = [(each_settings_file.split(temp)[-1]) for each_settings_file in json_names_full_paths]
+            batch_names = help.get_batch_names(json_names_full_paths)
+            self.batch_to_json_map = help.map_batches_to_files(json_names, batch_names)
+        return gr.update(choices=batch_names), gr.update(choices=batch_names)
+
     # load a different config
     def change_config_batch_run(self, json_name_list, file_path):
         temp = '\\' if help.is_windows() else '/'
@@ -1901,6 +1915,10 @@ class Download_tab:
                 self.gallery_tab_manager.img_rating_tag_checkbox_group,
                 self.gallery_tab_manager.gallery_comp
             ]
+        ).then(
+            fn=self.refresh_json_options,
+            inputs=[],
+            outputs=[self.all_json_files_checkboxgroup, self.quick_json_select]
         )
         self.run_button_batch.click(
             fn=self.make_run_visible,
@@ -1953,6 +1971,10 @@ class Download_tab:
                 self.gallery_tab_manager.img_rating_tag_checkbox_group,
                 self.gallery_tab_manager.gallery_comp
             ]
+        ).then(
+            fn=self.refresh_json_options,
+            inputs=[],
+            outputs=[self.all_json_files_checkboxgroup, self.quick_json_select]
         )
         self.remove_button_required.click(
             fn=self.check_box_group_handler_required,

--- a/UI_tabs/gallery_tab.py
+++ b/UI_tabs/gallery_tab.py
@@ -1096,6 +1096,11 @@ class Gallery_tab:
                 full_path = os.path.join(full_path_gallery_type, f"{img_id}.txt")
                 temp_tag_string = ",".join(self.all_images_dict[ext][img_id])
                 help.write_tags_to_text_file(temp_tag_string, full_path)  # update img txt file
+                if self.db_manager:
+                    img_path = os.path.join(full_path_gallery_type, f"{img_id}.{ext}")
+                    fid = self.db_manager.get_file_id(img_path)
+                    if fid:
+                        self.db_manager.add_modified_file(fid, mod_tag_path=full_path)
         # persist csv changes
         self.csv_persist_to_disk()
 


### PR DESCRIPTION
## Summary
- add helpers to track modified files in the database
- record gallery tag edits in `modified_files`
- refresh config dropdowns after runs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854bb86b9b0832189bd6c8a2b29b18a