### PR TITLE
Fix fetch_table limit handling

### DIFF
--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -33,3 +33,23 @@ def test_get_latest_config(tmp_path):
     assert loaded == cfg
     db.close()
 
+def test_fetch_table_limits(tmp_path):
+    db = setup_db(tmp_path)
+    dl = db.add_download_record('site')
+    img_path = os.path.join(tmp_path, 'img1.png')
+    with open(img_path, 'wb') as f:
+        f.write(b'0')
+    img_path2 = os.path.join(tmp_path, 'img2.png')
+    with open(img_path2, 'wb') as f:
+        f.write(b'1')
+    # add two distinct rows
+    db.add_file(dl, 'tag1', '2020-01-01', '2020-01-01', 'url1', img_path, '', '')
+    db.add_file(dl, 'tag2', '2020-01-02', '2020-01-02', 'url2', img_path2, '', '')
+
+    headers, rows = db.fetch_table('files', limit=None)
+    assert len(rows) == 2
+
+    headers, rows = db.fetch_table('files', limit=1)
+    assert len(rows) == 1
+    db.close()
+

--- a/utils/database.py
+++ b/utils/database.py
@@ -416,9 +416,15 @@ class DatabaseManager:
         with self.lock:
             cur = self.conn.cursor()
             if limit is None:
-                cur.execute(f"SELECT * FROM {table_name}")
+                query = f"SELECT * FROM {table_name}"
+                cur.execute(query)
             else:
-                cur.execute(f"SELECT * FROM {table_name} LIMIT ?", (limit,))
+                try:
+                    lim = int(limit)
+                except (TypeError, ValueError):
+                    raise ValueError("limit must be an integer or None")
+                query = f"SELECT * FROM {table_name} LIMIT {lim}"
+                cur.execute(query)
             rows = cur.fetchall()
             headers = [description[0] for description in cur.description]
             return headers, rows


### PR DESCRIPTION
## Summary
- guard `fetch_table` against non-integer limits and allow `None`
- test retrieving unlimited rows from tables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854cc8165448321a0f97780bcc461c1