### PR TITLE
Fix gallery mode search loading and optimize table view

### DIFF
--- a/UI_tabs/database_tab.py
+++ b/UI_tabs/database_tab.py
@@ -52,8 +52,9 @@ class Database_tab:
         if not table_name:
             return gr.update(), gr.update(value="No table selected")
         try:
-            headers, rows = self.db_manager.fetch_table(table_name)
-            count_msg = f"Total Rows: {len(rows)}"
+            headers, rows = self.db_manager.fetch_table(table_name, limit=100)
+            total = self.db_manager.count_rows(table_name)
+            count_msg = f"Showing {len(rows)} of {total} rows"
             return gr.update(value=rows, headers=headers, visible=True), gr.update(value=count_msg)
         except Exception as e:
             return gr.update(), gr.update(value=f"Error: {e}")

--- a/UI_tabs/gallery_tab.py
+++ b/UI_tabs/gallery_tab.py
@@ -1261,6 +1261,7 @@ class Gallery_tab:
 
     def show_searched_gallery(self, folder_type_select, sort_images, sort_option):
         # type select
+        self.current_media_mode = folder_type_select
         if "searched" in self.all_images_dict and len(
                 list(self.all_images_dict["searched"].keys())) > 0 and self.get_searched_image_total() > 0:
             images = self.update_search_gallery(sort_images, sort_option, folder_type_select)
@@ -2236,7 +2237,7 @@ class Gallery_tab:
             outputs=[self.multi_select_ckbx_state]
         )
         self.download_folder_type.change(
-            fn=self.show_gallery,
+            fn=self.show_searched_gallery,
             inputs=[self.download_folder_type, self.apply_datetime_sort_ckbx, self.apply_datetime_choice_menu],
             outputs=[self.gallery_comp]).then(
             fn=self.reset_selected_img,

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -53,3 +53,13 @@ def test_fetch_table_limits(tmp_path):
     assert len(rows) == 1
     db.close()
 
+def test_count_rows(tmp_path):
+    db = setup_db(tmp_path)
+    dl = db.add_download_record('site')
+    img_path = os.path.join(tmp_path, 'img.png')
+    with open(img_path, 'wb') as f:
+        f.write(b'0')
+    db.add_file(dl, 'tag1', '2020-01-01', '2020-01-01', 'url', img_path, '', '')
+    assert db.count_rows('files') == 1
+    db.close()
+

--- a/utils/database.py
+++ b/utils/database.py
@@ -443,6 +443,14 @@ class DatabaseManager:
         query = f"SELECT * FROM files WHERE {where}"
         return self.run_query(query, params)
 
+    def count_rows(self, table_name):
+        """Return the number of rows in a table."""
+        with self.lock:
+            cur = self.conn.cursor()
+            cur.execute(f"SELECT COUNT(*) FROM {table_name}")
+            result = cur.fetchone()
+            return result[0] if result else 0
+
     def copy_files_from_table(self, table_name, dest_dir):
         """Copy images referenced in a table to dest_dir."""
         os.makedirs(dest_dir, exist_ok=True)


### PR DESCRIPTION
## Summary
- show searched gallery on media mode changes to preserve loaded data
- only show first 100 rows when viewing database tables
- add helper for counting table rows
- preserve current media mode when viewing searched gallery
- test new `count_rows`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854e3124d8c8321aa22fe1a9ebf5001