### PR TITLE
Add toggle for tag suggestions

### DIFF
--- a/UI_tabs/advanced_settings_tab.py
+++ b/UI_tabs/advanced_settings_tab.py
@@ -3,8 +3,17 @@ import gradio as gr
 class Advanced_settings_tab:
     def render_tab(self):
         with gr.Tab("Advanced Settings"):
-            total_suggestions_slider = gr.Slider(info="Limit Number of Tag Suggestions", minimum=0, maximum=1000, step=1, value=10, show_label=False)
+            tag_suggestions_checkbox = gr.Checkbox(label="Enable Tag Suggestions", value=True)
+            total_suggestions_slider = gr.Slider(
+                info="Limit Number of Tag Suggestions",
+                minimum=0,
+                maximum=1000,
+                step=1,
+                value=10,
+                show_label=False,
+            )
 
+        self.tag_suggestions_checkbox = tag_suggestions_checkbox
         self.total_suggestions_slider = total_suggestions_slider
 
-        return self.total_suggestions_slider
+        return self.total_suggestions_slider, self.tag_suggestions_checkbox

--- a/UI_tabs/download_tab.py
+++ b/UI_tabs/download_tab.py
@@ -2049,7 +2049,13 @@ class Download_tab:
         )
         self.required_tags_textbox.change(
             fn=self.tag_ideas.suggest_tags,
-            inputs=[self.required_tags_textbox, self.initial_required_state, self.advanced_settings_tab_manager.total_suggestions_slider, self.initial_required_state_tag],
+            inputs=[
+                self.required_tags_textbox,
+                self.initial_required_state,
+                self.advanced_settings_tab_manager.total_suggestions_slider,
+                self.initial_required_state_tag,
+                self.advanced_settings_tab_manager.tag_suggestions_checkbox,
+            ],
             outputs=[self.tag_required_suggestion_dropdown, self.initial_required_state, self.initial_required_state_tag,
                      self.relevant_required_categories]).then(
             fn=self.textbox_handler_required,
@@ -2073,7 +2079,13 @@ class Download_tab:
         )
         self.blacklist_tags_textbox.change(
             fn=self.tag_ideas.suggest_tags,
-            inputs=[self.blacklist_tags_textbox, self.initial_blacklist_state, self.advanced_settings_tab_manager.total_suggestions_slider, self.initial_blacklist_state_tag],
+            inputs=[
+                self.blacklist_tags_textbox,
+                self.initial_blacklist_state,
+                self.advanced_settings_tab_manager.total_suggestions_slider,
+                self.initial_blacklist_state_tag,
+                self.advanced_settings_tab_manager.tag_suggestions_checkbox,
+            ],
             outputs=[self.tag_blacklist_suggestion_dropdown, self.initial_blacklist_state, self.initial_blacklist_state_tag,
                      self.relevant_blacklist_categories]).then(
             fn=self.textbox_handler_blacklist,

--- a/UI_tabs/gallery_tab.py
+++ b/UI_tabs/gallery_tab.py
@@ -2153,7 +2153,12 @@ class Gallery_tab:
         )
         self.tag_search_textbox.change(
             fn=self.tag_ideas.suggest_search_tags,
-            inputs=[self.tag_search_textbox, self.advanced_settings_tab_manager.total_suggestions_slider, self.previous_search_state_text],
+            inputs=[
+                self.tag_search_textbox,
+                self.advanced_settings_tab_manager.total_suggestions_slider,
+                self.previous_search_state_text,
+                self.advanced_settings_tab_manager.tag_suggestions_checkbox,
+            ],
             outputs=[self.tag_search_suggestion_dropdown, self.previous_search_state_text,
                     self.current_search_state_placement_tuple, self.relevant_search_categories]
         ).then(
@@ -2181,8 +2186,13 @@ class Gallery_tab:
         )
         self.tag_add_textbox.change(
             fn=self.tag_ideas.suggest_tags,
-            inputs=[self.tag_add_textbox, self.initial_add_state, self.advanced_settings_tab_manager.total_suggestions_slider,
-                    self.initial_add_state_tag],
+            inputs=[
+                self.tag_add_textbox,
+                self.initial_add_state,
+                self.advanced_settings_tab_manager.total_suggestions_slider,
+                self.initial_add_state_tag,
+                self.advanced_settings_tab_manager.tag_suggestions_checkbox,
+            ],
             outputs=[self.tag_add_suggestion_dropdown, self.initial_add_state, self.initial_add_state_tag, self.relevant_add_categories]).then(
             fn=self.add_tag_changes,
             inputs=[self.initial_add_state_tag, self.apply_to_all_type_select_checkboxgroup, self.img_id_textbox,

--- a/utils/features/tag_suggestions/tag_suggest.py
+++ b/utils/features/tag_suggestions/tag_suggest.py
@@ -6,11 +6,12 @@ from utils import helper_functions as help
 
 class Tag_Suggest:
 
-    def __init__(self, all_tags_ever_dict, gallery_tab_manager, download_tab_manager):
+    def __init__(self, all_tags_ever_dict, gallery_tab_manager, download_tab_manager, advanced_settings_tab_manager):
         self.trie = datrie.Trie(string.printable)
         help.load_trie(self.trie, all_tags_ever_dict)
         self.gallery_tab_manager = gallery_tab_manager
         self.download_tab_manager = download_tab_manager
+        self.advanced_settings_tab_manager = advanced_settings_tab_manager
 
     # Function to color code categories
     def category_color(self, category):
@@ -61,7 +62,10 @@ class Tag_Suggest:
         return tag_textbox, tag_suggestion_dropdown, state, state_tag, tag_categories
 
     # get the suggestions and populate the dropdown menu
-    def suggest_tags(self, input_string, state, num_suggestions, state_tag):
+    def suggest_tags(self, input_string, state, num_suggestions, state_tag, enable_suggestions=True):
+        if not enable_suggestions:
+            generic_dropdown = gr.update(choices=[], value=None)
+            return generic_dropdown, state, state_tag, []
         # print(f"input_string:\t{(input_string)}")
         # print(f"state:\t{(state)}")
         # print(f"num_suggestions:\t{(num_suggestions)}")
@@ -209,7 +213,11 @@ class Tag_Suggest:
         # If we're here, it means there was no change
         return (0, "")
 
-    def suggest_search_tags(self, input_string, num_suggestions, previous_text):
+    def suggest_search_tags(self, input_string, num_suggestions, previous_text, enable_suggestions=True):
+        if not enable_suggestions:
+            generic_dropdown = gr.update(choices=[], value=None)
+            current_placement_tuple = (0, "")
+            return generic_dropdown, input_string, current_placement_tuple, []
         # obtain the current information
         current_placement_tuple = self.identify_changing_tag(previous_text, input_string)
 

--- a/webui.py
+++ b/webui.py
@@ -263,7 +263,12 @@ def build_ui():
         ################################################################################################################
 
         # initialize tag suggestion feature
-        tag_ideas = Tag_Suggest(all_tags_ever_dict, gallery_tab_manager, download_tab_manager)
+        tag_ideas = Tag_Suggest(
+            all_tags_ever_dict,
+            gallery_tab_manager,
+            download_tab_manager,
+            advanced_settings_tab_manager,
+        )
         download_tab_manager.set_tag_ideas(tag_ideas)
         gallery_tab_manager.set_tag_ideas(tag_ideas)
 


### PR DESCRIPTION
## Summary
- add `Enable Tag Suggestions` checkbox on Advanced Settings tab
- pass checkbox state to `Tag_Suggest`
- return early from suggestion functions when disabled
- update events to include the new checkbox

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68642cf5a5788321b3305b0708fcb669