### PR TITLE
Add CLI flag to disable tag suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ The "DUPLICATE" run files (run.bat, mac_run.sh, linux_run.sh) residing in the Da
 ./RUN_FILE --server_port 7860
 ```
 
+> Skip loading tag suggestions to speed up startup
+```
+./RUN_FILE --disable_tag_suggestions
+```
+
 > OR CHOOSE ANY COMBINATION OF ^
 
 ## Important Information

--- a/UI_tabs/advanced_settings_tab.py
+++ b/UI_tabs/advanced_settings_tab.py
@@ -1,7 +1,7 @@
 import gradio as gr
 
 class Advanced_settings_tab:
-    def render_tab(self):
+    def render_tab(self, suggestions_enabled=True):
         with gr.Tab("Advanced Settings"):
             total_suggestions_slider = gr.Slider(
                 info="Limit Number of Tag Suggestions",
@@ -14,7 +14,7 @@ class Advanced_settings_tab:
 
             tag_suggestions_checkbox = gr.Checkbox(
                 label="Tag Suggestions",
-                value=True,
+                value=suggestions_enabled,
                 info="Enable search tag suggestions",
             )
 

--- a/utils/features/tag_suggestions/tag_suggest.py
+++ b/utils/features/tag_suggestions/tag_suggest.py
@@ -6,12 +6,15 @@ from utils import helper_functions as help
 
 class Tag_Suggest:
 
-    def __init__(self, all_tags_ever_dict, gallery_tab_manager, download_tab_manager, advanced_settings_tab_manager):
-        self.trie = datrie.Trie(string.printable)
-        help.load_trie(self.trie, all_tags_ever_dict)
+    def __init__(self, all_tags_ever_dict, gallery_tab_manager, download_tab_manager,
+                 advanced_settings_tab_manager, enable_suggestions=True):
+        self.trie = datrie.Trie(string.printable) if enable_suggestions else None
+        if enable_suggestions:
+            help.load_trie(self.trie, all_tags_ever_dict)
         self.gallery_tab_manager = gallery_tab_manager
         self.download_tab_manager = download_tab_manager
         self.advanced_settings_tab_manager = advanced_settings_tab_manager
+        self.enable_suggestions = enable_suggestions
 
     # Function to color code categories
     def category_color(self, category):
@@ -36,6 +39,9 @@ class Tag_Suggest:
             return str(count)
 
     def get_tag_options(self, input_string, num_suggestions):
+        if not self.trie:
+            return gr.update(value=input_string), gr.update(choices=[], value=None), input_string, "", []
+
         # Get a list of all tags that start with the edited part
         suggested_tags = self.trie.keys(input_string)
 
@@ -169,6 +175,9 @@ class Tag_Suggest:
 
     def get_search_tag_options(self, partial_tag, num_suggestions):
         tag_categories = []
+        if not self.trie:
+            return gr.update(choices=[], value=None), tag_categories
+
         if (partial_tag[0] == "-" and len(partial_tag) == 1):
             return gr.update(choices=[], value=None), tag_categories
         # check for leading "-" with additional text afterwards i.e. length exceeding 1 :: remove "-" if condition is true

--- a/webui.py
+++ b/webui.py
@@ -9,7 +9,7 @@ from utils.features.tag_suggestions.tag_suggest import Tag_Suggest
 from utils.features.image_boards.image_board_manager import Image_Board
 
 
-def build_ui():
+def build_ui(enable_tag_suggestions=True):
     from UI_tabs.download_tab import Download_tab
     from UI_tabs.gallery_tab import Gallery_tab
     from UI_tabs.stats_tab import Stats_tab
@@ -247,7 +247,7 @@ def build_ui():
         # advanced settings tab init
         advanced_settings_tab_manager = Advanced_settings_tab()
         # render tab
-        advanced_settings_tab_manager.render_tab()
+        advanced_settings_tab_manager.render_tab(enable_tag_suggestions)
         # share object reference
         download_tab_manager.set_advanced_settings_tab_manager(advanced_settings_tab_manager)
         gallery_tab_manager.set_advanced_settings_tab_manager(advanced_settings_tab_manager)
@@ -272,6 +272,7 @@ def build_ui():
             gallery_tab_manager,
             download_tab_manager,
             advanced_settings_tab_manager,
+            enable_tag_suggestions,
         )
         download_tab_manager.set_tag_ideas(tag_ideas)
         gallery_tab_manager.set_tag_ideas(tag_ideas)
@@ -332,9 +333,14 @@ if __name__ == "__main__":
         default=None,
         help='(Optional) Proxy URL for downloading tags.csv.gz file',
     )
+    parser.add_argument(
+        '--disable_tag_suggestions',
+        action='store_true',
+        help='Disable loading of tag suggestions to speed up startup',
+    )
     args = parser.parse_args()
 
-    demo = build_ui()
+    demo = build_ui(enable_tag_suggestions=not args.disable_tag_suggestions)
 
     UI(
         username=args.username,


### PR DESCRIPTION
## Summary
- allow disabling tag suggestions at startup
- propagate suggestion state into advanced settings UI and Tag_Suggest
- document `--disable_tag_suggestions` run option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686478a9bf248321ab4c369e1aac925c