### PR TITLE
Fix tag removal NameError

### DIFF
--- a/UI_tabs/gallery_tab.py
+++ b/UI_tabs/gallery_tab.py
@@ -863,9 +863,11 @@ class Gallery_tab:
     def remove_tag_changes(self, category_tag_checkbox_group, apply_to_all_type_select_checkboxgroup, img_id,
                            multi_select_ckbx_state, only_selected_state_object, images_selected_state):
 
+        # Initialize checkbox groups so the function always returns valid values
         img_artist_tag_checkbox_group = None
         img_character_tag_checkbox_group = None
         img_species_tag_checkbox_group = None
+        img_invalid_tag_checkbox_group = None
         img_general_tag_checkbox_group = None
         img_meta_tag_checkbox_group = None
         img_rating_tag_checkbox_group = None

--- a/utils/features/tag_suggestions/tag_suggest.py
+++ b/utils/features/tag_suggestions/tag_suggest.py
@@ -71,6 +71,8 @@ class Tag_Suggest:
     def suggest_tags(self, input_string, state, num_suggestions, state_tag, enable_suggestions=True):
         if not enable_suggestions:
             generic_dropdown = gr.update(choices=[], value=None)
+            # preserve whatever the user has typed so far
+            state = input_string
             return generic_dropdown, state, state_tag, []
         # print(f"input_string:\t{(input_string)}")
         # print(f"state:\t{(state)}")


### PR DESCRIPTION
## Summary
- avoid NameError in gallery removal logic by initializing checkbox groups
- keep user text when tag suggestions are disabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864c06d9f4483219adf654f5793a9b3