### PR TITLE
Fix multi-select search tag batch

### DIFF
--- a/UI_tabs/gallery_tab.py
+++ b/UI_tabs/gallery_tab.py
@@ -709,13 +709,14 @@ class Gallery_tab:
                         category_key = self.get_category_name(tag)
                         if category_key != "invalid":
                             self.add_to_csv_dictionaries(category_key, tag)  # add
-        if len(apply_to_all_type_select_checkboxgroup) > 0:
+        if apply_to_all_type_select_checkboxgroup and len(apply_to_all_type_select_checkboxgroup) > 0:
+            searched_only = set(apply_to_all_type_select_checkboxgroup) == {"searched"}
             if "searched" in apply_to_all_type_select_checkboxgroup:  # edit searched and then all the instances of the respective types
                 if multi_select_ckbx_state[0]:
                     ##### returns index -> [ext, img_id]
                     for index in images_selected_state:
                         ext, img_id = only_selected_state_object[index]
-                        if ext in apply_to_all_type_select_checkboxgroup:
+                        if ext in apply_to_all_type_select_checkboxgroup or searched_only:
                             if img_id in list(self.all_images_dict["searched"][ext].keys()):
                                 for tag in tag_list:
                                     if not tag in self.all_images_dict["searched"][ext][img_id]:  # add tag
@@ -783,7 +784,7 @@ class Gallery_tab:
                     ##### returns index -> [ext, img_id]
                     for index in images_selected_state:
                         ext, img_id = only_selected_state_object[index]
-                        if ext in apply_to_all_type_select_checkboxgroup:
+                        if ext in apply_to_all_type_select_checkboxgroup or searched_only:
                             if img_id in list(self.all_images_dict[ext].keys()):
                                 for tag in tag_list:
                                     if not tag in self.all_images_dict[ext][img_id]:
@@ -973,13 +974,14 @@ class Gallery_tab:
                         if category_key != "invalid":
                             self.remove_to_csv_dictionaries(category_key, tag)  # remove
 
-        if len(apply_to_all_type_select_checkboxgroup) > 0:
+        if apply_to_all_type_select_checkboxgroup and len(apply_to_all_type_select_checkboxgroup) > 0:
+            searched_only = set(apply_to_all_type_select_checkboxgroup) == {"searched"}
             if "searched" in apply_to_all_type_select_checkboxgroup:  # edit searched and then all the instances of the respective types
                 if multi_select_ckbx_state[0]:
                     ##### returns index -> [ext, img_id]
                     for index in images_selected_state:
                         ext, img_id = only_selected_state_object[index]
-                        if ext in apply_to_all_type_select_checkboxgroup:
+                        if ext in apply_to_all_type_select_checkboxgroup or searched_only:
                             if img_id in list(self.all_images_dict["searched"][ext].keys()):
                                 for tag in tag_list:
                                     if tag in self.all_images_dict["searched"][ext][img_id]:  # remove tag
@@ -1022,7 +1024,7 @@ class Gallery_tab:
                     ##### returns index -> [ext, img_id]
                     for index in images_selected_state:
                         ext, img_id = only_selected_state_object[index]
-                        if ext in apply_to_all_type_select_checkboxgroup:
+                        if ext in apply_to_all_type_select_checkboxgroup or searched_only:
                             if img_id in list(self.all_images_dict[ext].keys()):
                                 for tag in tag_list:
                                     if tag in self.all_images_dict[ext][img_id]:
@@ -1099,13 +1101,17 @@ class Gallery_tab:
     def remove_images(self, apply_to_all_type_select_checkboxgroup, image_id, sort_images, sort_option,
                       multi_select_ckbx_state, only_selected_state_object, images_selected_state):
         image_id = str(image_id)
+        if apply_to_all_type_select_checkboxgroup is None:
+            apply_to_all_type_select_checkboxgroup = []
+
+        searched_only = set(apply_to_all_type_select_checkboxgroup) == {"searched"}
 
         if not "searched" in apply_to_all_type_select_checkboxgroup:
             if multi_select_ckbx_state[0] and len(apply_to_all_type_select_checkboxgroup) > 0:
                 ##### returns index -> [ext, img_id]
                 for index in images_selected_state:
                     ext, img_id = only_selected_state_object[index]
-                    if ext in apply_to_all_type_select_checkboxgroup:
+                    if ext in apply_to_all_type_select_checkboxgroup or searched_only:
                         # iterate over all the tags for each image
                         for tag in self.all_images_dict[ext][img_id]:
                             category_key = self.get_category_name(tag)
@@ -1152,7 +1158,7 @@ class Gallery_tab:
                 ##### returns index -> [ext, img_id]
                 for index in images_selected_state:
                     ext, img_id = only_selected_state_object[index]
-                    if ext in apply_to_all_type_select_checkboxgroup:
+                    if ext in apply_to_all_type_select_checkboxgroup or searched_only:
                         # delete searched images and use the global dictionary to update the CSVs before deleting those as well
                         del self.all_images_dict["searched"][ext][img_id]
                         # iterate over all the tags for each image
@@ -1168,7 +1174,7 @@ class Gallery_tab:
             else:
                 # remove all images that are "searched"
                 for key_type in list(self.all_images_dict["searched"].keys()):
-                    if key_type in apply_to_all_type_select_checkboxgroup:
+                    if key_type in apply_to_all_type_select_checkboxgroup or searched_only:
                         for img_id in list(self.all_images_dict["searched"][key_type].keys()):
                             # delete searched images and use the global dictionary to update the CSVs before deleting those as well
                             del self.all_images_dict["searched"][key_type][img_id]


### PR DESCRIPTION
## Summary
- revert broken gallery loading logic
- support batch tag edits when only the 'searched' filter is enabled
- guard against None apply_to_all checkbox group

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68660d24c3a08321be0dc8df76199027