### PR TITLE
Add gallery multi-image comparison helpers

### DIFF
--- a/tests/test_image_tag_tools.py
+++ b/tests/test_image_tag_tools.py
@@ -1,0 +1,51 @@
+import os
+from utils.image_tag_tools import (
+    load_image_tags,
+    transfer_tags,
+    invert_selection,
+    compare_tags,
+    apply_tag_modifications,
+)
+
+
+def test_load_and_transfer_tags(tmp_path):
+    img1 = tmp_path / "img1.png"
+    img2 = tmp_path / "img2.png"
+    img1.write_bytes(b"1")
+    img2.write_bytes(b"1")
+    (tmp_path / "img1.txt").write_text("tagA\ntagB\n")
+    (tmp_path / "img2.txt").write_text("tagB\n")
+
+    tags = load_image_tags(str(img1))
+    assert tags == ["tagA", "tagB"]
+
+    transfer_tags(str(img1), str(img2), ["tagA"], remove=True)
+
+    assert load_image_tags(str(img2)) == ["tagB", "tagA"]
+    assert load_image_tags(str(img1)) == ["tagB"]
+
+
+def test_invert_selection():
+    all_items = [1, 2, 3, 4]
+    selected = [2, 4]
+    assert invert_selection(selected, all_items) == [1, 3]
+
+
+def test_compare_and_apply(tmp_path):
+    img1 = tmp_path / "img1.png"
+    img2 = tmp_path / "img2.png"
+    img3 = tmp_path / "img3.png"
+    for img in (img1, img2, img3):
+        img.write_bytes(b"1")
+
+    (tmp_path / "img1.txt").write_text("a\nb\nc")
+    (tmp_path / "img2.txt").write_text("b\nc\nd")
+    (tmp_path / "img3.txt").write_text("c")
+
+    diff = compare_tags(str(img1), str(img2))
+    assert diff["a_only"] == ["a"]
+    assert diff["b_only"] == ["d"]
+    assert diff["common"] == ["b", "c"]
+
+    apply_tag_modifications([str(img3)], add_tags=diff["a_only"], remove_tags=[])
+    assert load_image_tags(str(img3)) == ["a", "c"]

--- a/utils/image_tag_tools.py
+++ b/utils/image_tag_tools.py
@@ -1,0 +1,89 @@
+import os
+from .helper_functions import parse_single_all_tags, write_tags_to_text_file
+
+
+def load_image_tags(image_path):
+    """Return list of tags for given image path.
+
+    Looks for a sibling ``.txt`` file with the same basename.
+    Returns an empty list if the tag file does not exist.
+    """
+    tag_path = os.path.splitext(image_path)[0] + '.txt'
+    tags = parse_single_all_tags(tag_path)
+    return [t.strip() for t in tags if t.strip()]
+
+
+def transfer_tags(src_image, dest_image, tags, remove=False):
+    """Transfer ``tags`` from ``src_image`` to ``dest_image``.
+
+    Tags already present in ``dest_image`` are not duplicated. If
+    ``remove`` is True, transferred tags are removed from ``src_image``.
+    """
+    src_tags = load_image_tags(src_image)
+    dest_tags = load_image_tags(dest_image)
+
+    for t in tags:
+        if t not in dest_tags:
+            dest_tags.append(t)
+        if remove and t in src_tags:
+            src_tags.remove(t)
+
+    write_tags_to_text_file('\n'.join(dest_tags), os.path.splitext(dest_image)[0] + '.txt')
+    if remove:
+        write_tags_to_text_file('\n'.join(src_tags), os.path.splitext(src_image)[0] + '.txt')
+
+
+def invert_selection(selected, all_items):
+    """Return items from ``all_items`` that are not in ``selected``."""
+    selected_set = set(selected)
+    return [item for item in all_items if item not in selected_set]
+
+
+def compare_tags(image_a, image_b):
+    """Compare tags of two images.
+
+    Parameters
+    ----------
+    image_a : str
+        Path to the first image file.
+    image_b : str
+        Path to the second image file.
+
+    Returns
+    -------
+    dict
+        Mapping with keys ``"a_only"``, ``"b_only"`` and ``"common"`` denoting
+        tags only present in ``image_a``, only in ``image_b`` and in both
+        respectively. All tag lists are sorted alphabetically.
+    """
+    tags_a = set(load_image_tags(image_a))
+    tags_b = set(load_image_tags(image_b))
+
+    return {
+        "a_only": sorted(tags_a - tags_b),
+        "b_only": sorted(tags_b - tags_a),
+        "common": sorted(tags_a & tags_b),
+    }
+
+
+def apply_tag_modifications(image_paths, add_tags=None, remove_tags=None):
+    """Apply tag additions/removals to multiple images.
+
+    Parameters
+    ----------
+    image_paths : Iterable[str]
+        Collection of image file paths to modify.
+    add_tags : Iterable[str], optional
+        Tags to add to each image. Existing tags are not duplicated.
+    remove_tags : Iterable[str], optional
+        Tags to remove from each image if present.
+    """
+    add_tags = set(add_tags or [])
+    remove_tags = set(remove_tags or [])
+
+    for img in image_paths:
+        tags = load_image_tags(img)
+        tag_set = set(tags)
+        tag_set.update(add_tags)
+        tag_set.difference_update(remove_tags)
+        write_tags_to_text_file("\n".join(sorted(tag_set)), os.path.splitext(img)[0] + ".txt")


### PR DESCRIPTION
## Summary
- expand `image_tag_tools` with tag comparison and batch modification helpers
- add selection management features in `Gallery_tab` (select all, deselect, invert)
- support comparing two images directly in the gallery
- extend tests for new utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866ff1898548321ba733f3a6a864121