### PR TITLE
Add side-by-side tag comparison

### DIFF
--- a/UI_tabs/gallery_tab.py
+++ b/UI_tabs/gallery_tab.py
@@ -4,7 +4,7 @@ import copy
 import datetime
 import glob
 
-from utils import js_constants as js_, md_constants as md_, helper_functions as help
+from utils import js_constants as js_, md_constants as md_, helper_functions as help, image_tag_tools
 
 
 class Gallery_tab:
@@ -71,6 +71,10 @@ class Gallery_tab:
         # stores the currently displayed gallery image paths to avoid passing
         # filepaths through gradio inputs
         self.gallery_state = gr.State([])
+
+        # buffers holding tags transferred/removed during compare operations
+        self.transfer_buffer = []  # tags to add when applying to other images
+        self.remove_buffer = []    # tags to remove when applying to other images
 
         # optional path to a user provided dataset loaded via the
         # custom dataset tab
@@ -1494,6 +1498,115 @@ class Gallery_tab:
         multi_select_ckbx_state = [select_multiple_images_checkbox]
         return multi_select_ckbx_state
 
+    def select_all(self, gallery_images):
+        """Return indices of all images for selection."""
+        return list(range(len(gallery_images)))
+
+    def deselect_all(self):
+        """Return empty selection list."""
+        return []
+
+    def invert_selected(self, gallery_images, images_selected_state):
+        all_indices = set(range(len(gallery_images)))
+        selected = set(images_selected_state)
+        return sorted(list(all_indices - selected))
+
+    def handle_select_all(self, gallery_images):
+        return self.select_all(gallery_images)
+
+    def handle_deselect_all(self):
+        return self.deselect_all()
+
+    def handle_invert_selection(self, gallery_images, images_selected_state):
+        return self.invert_selected(gallery_images, images_selected_state)
+
+    def compare_selected(self, gallery_images, images_selected_state):
+        if len(images_selected_state) != 2:
+            empty = [gr.update(value=None)] + [gr.update(choices=[], value=[]) for _ in range(7)]
+            return empty + empty
+        paths = [gallery_images[idx][0] if isinstance(gallery_images[idx], (list, tuple)) else gallery_images[idx]
+                 for idx in images_selected_state]
+        self.compare_left_path = paths[0]
+        self.compare_right_path = paths[1]
+        # reset accumulated tag actions when a new pair is compared
+        self.transfer_buffer = []
+        self.remove_buffer = []
+
+        left_tags = help.parse_single_all_tags(os.path.splitext(paths[0])[0] + ".txt")
+        right_tags = help.parse_single_all_tags(os.path.splitext(paths[1])[0] + ".txt")
+
+        def categorize(tags):
+            groups = {"artist": [], "character": [], "species": [], "invalid": [], "general": [], "meta": [], "rating": []}
+            for t in tags:
+                cat = self.get_category_name(t)
+                if cat not in groups:
+                    cat = "invalid"
+                groups[cat].append(t)
+            return groups
+
+        left_groups = categorize(left_tags)
+        right_groups = categorize(right_tags)
+
+        outputs = [gr.update(value=paths[0])]
+        outputs += [gr.update(choices=left_groups[k], value=[]) for k in ["artist","character","species","invalid","general","meta","rating"]]
+        outputs.append(gr.update(value=paths[1]))
+        outputs += [gr.update(choices=right_groups[k], value=[]) for k in ["artist","character","species","invalid","general","meta","rating"]]
+        return outputs
+
+    def transfer_left_to_right(self, left_artist, left_character, left_species, left_invalid,
+                               left_general, left_meta, left_rating):
+        if not hasattr(self, "compare_left_path") or not hasattr(self, "compare_right_path"):
+            return [gr.update() for _ in range(7)]
+        tags = left_artist + left_character + left_species + left_invalid + left_general + left_meta + left_rating
+        image_tag_tools.transfer_tags(self.compare_left_path, self.compare_right_path, tags, remove=False)
+        self.transfer_buffer = sorted(set(self.transfer_buffer + tags))
+        groups = self.compare_selected([self.compare_left_path, self.compare_right_path], [0,1])[8:]
+        return groups[1:]
+
+    def remove_left_from_right(self, left_artist, left_character, left_species, left_invalid,
+                               left_general, left_meta, left_rating):
+        if not hasattr(self, "compare_left_path") or not hasattr(self, "compare_right_path"):
+            return [gr.update() for _ in range(7)]
+        tags = left_artist + left_character + left_species + left_invalid + left_general + left_meta + left_rating
+        image_tag_tools.apply_tag_modifications([self.compare_right_path], remove_tags=tags)
+        self.remove_buffer = sorted(set(self.remove_buffer + tags))
+        groups = self.compare_selected([self.compare_left_path, self.compare_right_path], [0,1])[8:]
+        return groups[1:]
+
+    def transfer_right_to_left(self, right_artist, right_character, right_species, right_invalid,
+                               right_general, right_meta, right_rating):
+        if not hasattr(self, "compare_left_path") or not hasattr(self, "compare_right_path"):
+            return [gr.update() for _ in range(7)]
+        tags = right_artist + right_character + right_species + right_invalid + right_general + right_meta + right_rating
+        image_tag_tools.transfer_tags(self.compare_right_path, self.compare_left_path, tags, remove=False)
+        self.transfer_buffer = sorted(set(self.transfer_buffer + tags))
+        groups = self.compare_selected([self.compare_left_path, self.compare_right_path], [0,1])[:8]
+        return groups[1:]
+
+    def remove_right_from_left(self, right_artist, right_character, right_species, right_invalid,
+                               right_general, right_meta, right_rating):
+        if not hasattr(self, "compare_left_path") or not hasattr(self, "compare_right_path"):
+            return [gr.update() for _ in range(7)]
+        tags = right_artist + right_character + right_species + right_invalid + right_general + right_meta + right_rating
+        image_tag_tools.apply_tag_modifications([self.compare_left_path], remove_tags=tags)
+        self.remove_buffer = sorted(set(self.remove_buffer + tags))
+        groups = self.compare_selected([self.compare_left_path, self.compare_right_path], [0,1])[:8]
+        return groups[1:]
+
+    def apply_transfer_to_selected(self, gallery_images, images_selected_state):
+        paths = [gallery_images[idx][0] if isinstance(gallery_images[idx], (list, tuple)) else gallery_images[idx]
+                 for idx in images_selected_state]
+        if self.transfer_buffer:
+            image_tag_tools.apply_tag_modifications(paths, add_tags=self.transfer_buffer)
+        return []
+
+    def apply_remove_to_selected(self, gallery_images, images_selected_state):
+        paths = [gallery_images[idx][0] if isinstance(gallery_images[idx], (list, tuple)) else gallery_images[idx]
+                 for idx in images_selected_state]
+        if self.remove_buffer:
+            image_tag_tools.apply_tag_modifications(paths, remove_tags=self.remove_buffer)
+        return []
+
     ######
     # self.all_images_dict ->
     ### image_type -> {img_id, tags}
@@ -1797,6 +1910,9 @@ class Gallery_tab:
         apply_to_all_type_select_checkboxgroup = gr.update(value=[])
         select_multiple_images_checkbox = gr.update(value=False)
         select_between_images_checkbox = gr.update(value=False)
+        select_all_checkbox = gr.update(value=False)
+        deselect_all_checkbox = gr.update(value=False)
+        invert_selection_checkbox = gr.update(value=False)
         apply_datetime_sort_ckbx = gr.update(value=False)
         apply_datetime_choice_menu = gr.update(value=None)
         send_img_from_gallery_dropdown = gr.update(value=None)
@@ -1812,6 +1928,29 @@ class Gallery_tab:
         img_meta_tag_checkbox_group = gr.update(value=[])
         img_rating_tag_checkbox_group = gr.update(value=[])
         gallery_comp = gr.update(value=None)
+        compare_button = gr.update()
+        compare_image_left = gr.update(value=None)
+        comp_left_artist = gr.update(choices=[], value=[])
+        comp_left_character = gr.update(choices=[], value=[])
+        comp_left_species = gr.update(choices=[], value=[])
+        comp_left_invalid = gr.update(choices=[], value=[])
+        comp_left_general = gr.update(choices=[], value=[])
+        comp_left_meta = gr.update(choices=[], value=[])
+        comp_left_rating = gr.update(choices=[], value=[])
+        compare_image_right = gr.update(value=None)
+        comp_right_artist = gr.update(choices=[], value=[])
+        comp_right_character = gr.update(choices=[], value=[])
+        comp_right_species = gr.update(choices=[], value=[])
+        comp_right_invalid = gr.update(choices=[], value=[])
+        comp_right_general = gr.update(choices=[], value=[])
+        comp_right_meta = gr.update(choices=[], value=[])
+        comp_right_rating = gr.update(choices=[], value=[])
+        transfer_tags_button = gr.update()
+        remove_tags_button = gr.update()
+        transfer_tags_button_rl = gr.update()
+        remove_tags_button_rl = gr.update()
+        apply_transfer_button = gr.update()
+        apply_remove_button = gr.update()
 
         self.multi_select_ckbx_state = gr.JSON([False], visible=False) # JSON boolean component wrapped in a list
         self.only_selected_state_object = gr.State(dict()) # state of image mappings represented by index -> [ext, img_id]
@@ -1832,6 +1971,9 @@ class Gallery_tab:
                 apply_to_all_type_select_checkboxgroup,
                 select_multiple_images_checkbox,
                 select_between_images_checkbox,
+                select_all_checkbox,
+                deselect_all_checkbox,
+                invert_selection_checkbox,
                 apply_datetime_sort_ckbx,
                 apply_datetime_choice_menu,
                 send_img_from_gallery_dropdown,
@@ -1846,7 +1988,30 @@ class Gallery_tab:
                 img_general_tag_checkbox_group,
                 img_meta_tag_checkbox_group,
                 img_rating_tag_checkbox_group,
-                gallery_comp
+                gallery_comp,
+                compare_button,
+                compare_image_left,
+                comp_left_artist,
+                comp_left_character,
+                comp_left_species,
+                comp_left_invalid,
+                comp_left_general,
+                comp_left_meta,
+                comp_left_rating,
+                compare_image_right,
+                comp_right_artist,
+                comp_right_character,
+                comp_right_species,
+                comp_right_invalid,
+                comp_right_general,
+                comp_right_meta,
+                comp_right_rating,
+                transfer_tags_button,
+                remove_tags_button,
+                transfer_tags_button_rl,
+                remove_tags_button_rl,
+                apply_transfer_button,
+                apply_remove_button
                 ]
 
 
@@ -2139,6 +2304,13 @@ class Gallery_tab:
                                                                              info="Selects All Between Two Images")
                         with gr.Row():
                             with gr.Column(min_width=50, scale=1):
+                                select_all_checkbox = gr.Checkbox(label="Select All", value=False)
+                            with gr.Column(min_width=50, scale=1):
+                                deselect_all_checkbox = gr.Checkbox(label="Deselect All", value=False)
+                            with gr.Column(min_width=50, scale=1):
+                                invert_selection_checkbox = gr.Checkbox(label="Invert", value=False)
+                        with gr.Row():
+                            with gr.Column(min_width=50, scale=1):
                                 apply_datetime_sort_ckbx = gr.Checkbox(label="Sort", value=False,
                                                                        info="Image/s by date")
                             with gr.Column(min_width=50, scale=4):
@@ -2157,6 +2329,35 @@ class Gallery_tab:
                             with gr.Column(min_width=50, scale=3):
                                 send_img_from_gallery_button = gr.Button(value="Send Image to (Other) Tab",
                                                                          variant='primary')
+                        with gr.Row():
+                            compare_button = gr.Button(value="Compare Selected", variant='secondary')
+                        with gr.Row():
+                            with gr.Column():
+                                compare_image_left = gr.Image(type="filepath")
+                                comp_left_artist = gr.CheckboxGroup(label='Artist Tag/s', choices=[])
+                                comp_left_character = gr.CheckboxGroup(label='Character Tag/s', choices=[])
+                                comp_left_species = gr.CheckboxGroup(label='Species Tag/s', choices=[])
+                                comp_left_invalid = gr.CheckboxGroup(label='Invalid Tag/s', choices=[])
+                                comp_left_general = gr.CheckboxGroup(label='General Tag/s', choices=[])
+                                comp_left_meta = gr.CheckboxGroup(label='Meta Tag/s', choices=[])
+                                comp_left_rating = gr.CheckboxGroup(label='Rating Tag/s', choices=[])
+                            with gr.Column():
+                                compare_image_right = gr.Image(type="filepath")
+                                comp_right_artist = gr.CheckboxGroup(label='Artist Tag/s', choices=[])
+                                comp_right_character = gr.CheckboxGroup(label='Character Tag/s', choices=[])
+                                comp_right_species = gr.CheckboxGroup(label='Species Tag/s', choices=[])
+                                comp_right_invalid = gr.CheckboxGroup(label='Invalid Tag/s', choices=[])
+                                comp_right_general = gr.CheckboxGroup(label='General Tag/s', choices=[])
+                                comp_right_meta = gr.CheckboxGroup(label='Meta Tag/s', choices=[])
+                                comp_right_rating = gr.CheckboxGroup(label='Rating Tag/s', choices=[])
+                        with gr.Row():
+                            transfer_tags_button = gr.Button(value="Transfer Left Tags → Right", variant='secondary')
+                            remove_tags_button = gr.Button(value="Remove Left Tags from Right", variant='secondary')
+                            transfer_tags_button_rl = gr.Button(value="Transfer Right Tags → Left", variant='secondary')
+                            remove_tags_button_rl = gr.Button(value="Remove Right Tags from Left", variant='secondary')
+                        with gr.Row():
+                            apply_transfer_button = gr.Button(value="Apply Transfer Tags to Selected", variant='primary')
+                            apply_remove_button = gr.Button(value="Apply Remove Tags to Selected", variant='primary')
 
                     with gr.Accordion("Tag Edit & Selection Options"):
                         with gr.Row():
@@ -2218,6 +2419,9 @@ class Gallery_tab:
         self.apply_to_all_type_select_checkboxgroup = apply_to_all_type_select_checkboxgroup
         self.select_multiple_images_checkbox = select_multiple_images_checkbox
         self.select_between_images_checkbox = select_between_images_checkbox
+        self.select_all_checkbox = select_all_checkbox
+        self.deselect_all_checkbox = deselect_all_checkbox
+        self.invert_selection_checkbox = invert_selection_checkbox
         self.apply_datetime_sort_ckbx = apply_datetime_sort_ckbx
         self.apply_datetime_choice_menu = apply_datetime_choice_menu
         self.image_remove_button = image_remove_button
@@ -2225,6 +2429,29 @@ class Gallery_tab:
         self.send_img_from_gallery_dropdown = send_img_from_gallery_dropdown
         self.batch_send_from_gallery_checkbox = batch_send_from_gallery_checkbox
         self.send_img_from_gallery_button = send_img_from_gallery_button
+        self.compare_button = compare_button
+        self.compare_image_left = compare_image_left
+        self.comp_left_artist = comp_left_artist
+        self.comp_left_character = comp_left_character
+        self.comp_left_species = comp_left_species
+        self.comp_left_invalid = comp_left_invalid
+        self.comp_left_general = comp_left_general
+        self.comp_left_meta = comp_left_meta
+        self.comp_left_rating = comp_left_rating
+        self.compare_image_right = compare_image_right
+        self.comp_right_artist = comp_right_artist
+        self.comp_right_character = comp_right_character
+        self.comp_right_species = comp_right_species
+        self.comp_right_invalid = comp_right_invalid
+        self.comp_right_general = comp_right_general
+        self.comp_right_meta = comp_right_meta
+        self.comp_right_rating = comp_right_rating
+        self.transfer_tags_button = transfer_tags_button
+        self.remove_tags_button = remove_tags_button
+        self.transfer_tags_button_rl = transfer_tags_button_rl
+        self.remove_tags_button_rl = remove_tags_button_rl
+        self.apply_transfer_button = apply_transfer_button
+        self.apply_remove_button = apply_remove_button
         self.tag_remove_button = tag_remove_button
         self.tag_save_button = tag_save_button
         self.tag_add_textbox = tag_add_textbox
@@ -2259,6 +2486,9 @@ class Gallery_tab:
                 self.apply_to_all_type_select_checkboxgroup,
                 self.select_multiple_images_checkbox,
                 self.select_between_images_checkbox,
+                self.select_all_checkbox,
+                self.deselect_all_checkbox,
+                self.invert_selection_checkbox,
                 self.apply_datetime_sort_ckbx,
                 self.apply_datetime_choice_menu,
                 self.image_remove_button,
@@ -2266,6 +2496,29 @@ class Gallery_tab:
                 self.send_img_from_gallery_dropdown,
                 self.batch_send_from_gallery_checkbox,
                 self.send_img_from_gallery_button,
+                self.compare_button,
+                self.compare_image_left,
+                self.comp_left_artist,
+                self.comp_left_character,
+                self.comp_left_species,
+                self.comp_left_invalid,
+                self.comp_left_general,
+                self.comp_left_meta,
+                self.comp_left_rating,
+                self.compare_image_right,
+                self.comp_right_artist,
+                self.comp_right_character,
+                self.comp_right_species,
+                self.comp_right_invalid,
+                self.comp_right_general,
+                self.comp_right_meta,
+                self.comp_right_rating,
+                self.transfer_tags_button,
+                self.remove_tags_button,
+                transfer_tags_button_rl,
+                remove_tags_button_rl,
+                apply_transfer_button,
+                apply_remove_button,
                 self.tag_remove_button,
                 self.tag_save_button,
                 self.tag_add_textbox,
@@ -2453,6 +2706,137 @@ class Gallery_tab:
             fn=self.set_ckbx_state,
             inputs=[self.select_multiple_images_checkbox, self.multi_select_ckbx_state],
             outputs=[self.multi_select_ckbx_state]
+        )
+        self.select_all_checkbox.change(
+            fn=self.handle_select_all,
+            inputs=[self.gallery_state],
+            outputs=[self.images_selected_state]
+        )
+        self.deselect_all_checkbox.change(
+            fn=self.handle_deselect_all,
+            inputs=[],
+            outputs=[self.images_selected_state]
+        )
+        self.invert_selection_checkbox.change(
+            fn=self.handle_invert_selection,
+            inputs=[self.gallery_state, self.images_selected_state],
+            outputs=[self.images_selected_state]
+        )
+        self.compare_button.click(
+            fn=self.compare_selected,
+            inputs=[self.gallery_state, self.images_selected_state],
+            outputs=[
+                self.compare_image_left,
+                self.comp_left_artist,
+                self.comp_left_character,
+                self.comp_left_species,
+                self.comp_left_invalid,
+                self.comp_left_general,
+                self.comp_left_meta,
+                self.comp_left_rating,
+                self.compare_image_right,
+                self.comp_right_artist,
+                self.comp_right_character,
+                self.comp_right_species,
+                self.comp_right_invalid,
+                self.comp_right_general,
+                self.comp_right_meta,
+                self.comp_right_rating,
+            ]
+        )
+        self.transfer_tags_button.click(
+            fn=self.transfer_left_to_right,
+            inputs=[
+                self.comp_left_artist,
+                self.comp_left_character,
+                self.comp_left_species,
+                self.comp_left_invalid,
+                self.comp_left_general,
+                self.comp_left_meta,
+                self.comp_left_rating,
+            ],
+            outputs=[
+                self.comp_right_artist,
+                self.comp_right_character,
+                self.comp_right_species,
+                self.comp_right_invalid,
+                self.comp_right_general,
+                self.comp_right_meta,
+                self.comp_right_rating,
+            ]
+        )
+        self.remove_tags_button.click(
+            fn=self.remove_left_from_right,
+            inputs=[
+                self.comp_left_artist,
+                self.comp_left_character,
+                self.comp_left_species,
+                self.comp_left_invalid,
+                self.comp_left_general,
+                self.comp_left_meta,
+                self.comp_left_rating,
+            ],
+            outputs=[
+                self.comp_right_artist,
+                self.comp_right_character,
+                self.comp_right_species,
+                self.comp_right_invalid,
+                self.comp_right_general,
+                self.comp_right_meta,
+                self.comp_right_rating,
+            ]
+        )
+        self.transfer_tags_button_rl.click(
+            fn=self.transfer_right_to_left,
+            inputs=[
+                self.comp_right_artist,
+                self.comp_right_character,
+                self.comp_right_species,
+                self.comp_right_invalid,
+                self.comp_right_general,
+                self.comp_right_meta,
+                self.comp_right_rating,
+            ],
+            outputs=[
+                self.comp_left_artist,
+                self.comp_left_character,
+                self.comp_left_species,
+                self.comp_left_invalid,
+                self.comp_left_general,
+                self.comp_left_meta,
+                self.comp_left_rating,
+            ]
+        )
+        self.remove_tags_button_rl.click(
+            fn=self.remove_right_from_left,
+            inputs=[
+                self.comp_right_artist,
+                self.comp_right_character,
+                self.comp_right_species,
+                self.comp_right_invalid,
+                self.comp_right_general,
+                self.comp_right_meta,
+                self.comp_right_rating,
+            ],
+            outputs=[
+                self.comp_left_artist,
+                self.comp_left_character,
+                self.comp_left_species,
+                self.comp_left_invalid,
+                self.comp_left_general,
+                self.comp_left_meta,
+                self.comp_left_rating,
+            ]
+        )
+        self.apply_transfer_button.click(
+            fn=self.apply_transfer_to_selected,
+            inputs=[self.gallery_state, self.images_selected_state],
+            outputs=[]
+        )
+        self.apply_remove_button.click(
+            fn=self.apply_remove_to_selected,
+            inputs=[self.gallery_state, self.images_selected_state],
+            outputs=[]
         )
         self.download_folder_type.change(
             fn=self.show_searched_gallery,

--- a/tests/test_image_tag_tools.py
+++ b/tests/test_image_tag_tools.py
@@ -1,0 +1,65 @@
+import os
+from utils.image_tag_tools import (
+    load_image_tags,
+    transfer_tags,
+    invert_selection,
+    compare_tags,
+    apply_tag_modifications,
+)
+
+
+def test_load_and_transfer_tags(tmp_path):
+    img1 = tmp_path / "img1.png"
+    img2 = tmp_path / "img2.png"
+    img1.write_bytes(b"1")
+    img2.write_bytes(b"1")
+    (tmp_path / "img1.txt").write_text("tagA\ntagB\n")
+    (tmp_path / "img2.txt").write_text("tagB\n")
+
+    tags = load_image_tags(str(img1))
+    assert tags == ["tagA", "tagB"]
+
+    transfer_tags(str(img1), str(img2), ["tagA"], remove=True)
+
+    assert load_image_tags(str(img2)) == ["tagB", "tagA"]
+    assert load_image_tags(str(img1)) == ["tagB"]
+
+
+def test_invert_selection():
+    all_items = [1, 2, 3, 4]
+    selected = [2, 4]
+    assert invert_selection(selected, all_items) == [1, 3]
+
+
+def test_compare_and_apply(tmp_path):
+    img1 = tmp_path / "img1.png"
+    img2 = tmp_path / "img2.png"
+    img3 = tmp_path / "img3.png"
+    for img in (img1, img2, img3):
+        img.write_bytes(b"1")
+
+    (tmp_path / "img1.txt").write_text("a\nb\nc")
+    (tmp_path / "img2.txt").write_text("b\nc\nd")
+    (tmp_path / "img3.txt").write_text("c")
+
+    diff = compare_tags(str(img1), str(img2))
+    assert diff["a_only"] == ["a"]
+    assert diff["b_only"] == ["d"]
+    assert diff["common"] == ["b", "c"]
+
+    apply_tag_modifications([str(img3)], add_tags=diff["a_only"], remove_tags=[])
+    assert load_image_tags(str(img3)) == ["a", "c"]
+
+
+def test_apply_modifications_multiple(tmp_path):
+    img1 = tmp_path / "imgA.png"
+    img2 = tmp_path / "imgB.png"
+    for img in (img1, img2):
+        img.write_bytes(b"1")
+    (tmp_path / "imgA.txt").write_text("a\nb\n")
+    (tmp_path / "imgB.txt").write_text("b\nc\n")
+
+    apply_tag_modifications([str(img1), str(img2)], add_tags=["d"], remove_tags=["a"])
+
+    assert load_image_tags(str(img1)) == ["b", "d"]
+    assert load_image_tags(str(img2)) == ["b", "c", "d"]

--- a/utils/image_tag_tools.py
+++ b/utils/image_tag_tools.py
@@ -1,0 +1,89 @@
+import os
+from .helper_functions import parse_single_all_tags, write_tags_to_text_file
+
+
+def load_image_tags(image_path):
+    """Return list of tags for given image path.
+
+    Looks for a sibling ``.txt`` file with the same basename.
+    Returns an empty list if the tag file does not exist.
+    """
+    tag_path = os.path.splitext(image_path)[0] + '.txt'
+    tags = parse_single_all_tags(tag_path)
+    return [t.strip() for t in tags if t.strip()]
+
+
+def transfer_tags(src_image, dest_image, tags, remove=False):
+    """Transfer ``tags`` from ``src_image`` to ``dest_image``.
+
+    Tags already present in ``dest_image`` are not duplicated. If
+    ``remove`` is True, transferred tags are removed from ``src_image``.
+    """
+    src_tags = load_image_tags(src_image)
+    dest_tags = load_image_tags(dest_image)
+
+    for t in tags:
+        if t not in dest_tags:
+            dest_tags.append(t)
+        if remove and t in src_tags:
+            src_tags.remove(t)
+
+    write_tags_to_text_file('\n'.join(dest_tags), os.path.splitext(dest_image)[0] + '.txt')
+    if remove:
+        write_tags_to_text_file('\n'.join(src_tags), os.path.splitext(src_image)[0] + '.txt')
+
+
+def invert_selection(selected, all_items):
+    """Return items from ``all_items`` that are not in ``selected``."""
+    selected_set = set(selected)
+    return [item for item in all_items if item not in selected_set]
+
+
+def compare_tags(image_a, image_b):
+    """Compare tags of two images.
+
+    Parameters
+    ----------
+    image_a : str
+        Path to the first image file.
+    image_b : str
+        Path to the second image file.
+
+    Returns
+    -------
+    dict
+        Mapping with keys ``"a_only"``, ``"b_only"`` and ``"common"`` denoting
+        tags only present in ``image_a``, only in ``image_b`` and in both
+        respectively. All tag lists are sorted alphabetically.
+    """
+    tags_a = set(load_image_tags(image_a))
+    tags_b = set(load_image_tags(image_b))
+
+    return {
+        "a_only": sorted(tags_a - tags_b),
+        "b_only": sorted(tags_b - tags_a),
+        "common": sorted(tags_a & tags_b),
+    }
+
+
+def apply_tag_modifications(image_paths, add_tags=None, remove_tags=None):
+    """Apply tag additions/removals to multiple images.
+
+    Parameters
+    ----------
+    image_paths : Iterable[str]
+        Collection of image file paths to modify.
+    add_tags : Iterable[str], optional
+        Tags to add to each image. Existing tags are not duplicated.
+    remove_tags : Iterable[str], optional
+        Tags to remove from each image if present.
+    """
+    add_tags = set(add_tags or [])
+    remove_tags = set(remove_tags or [])
+
+    for img in image_paths:
+        tags = load_image_tags(img)
+        tag_set = set(tags)
+        tag_set.update(add_tags)
+        tag_set.difference_update(remove_tags)
+        write_tags_to_text_file("\n".join(sorted(tag_set)), os.path.splitext(img)[0] + ".txt")


### PR DESCRIPTION
## Summary
- show compare images and tag checkbox groups for each image
- allow transferring or removing selected tags from left to right or right to left
- add buffers for batch applying transferred/removed tags to selected images
- add tests for batch tag modification

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866ff1898548321ba733f3a6a864121