### PR TITLE
Implement group management for gallery

### DIFF
--- a/UI_tabs/gallery_tab.py
+++ b/UI_tabs/gallery_tab.py
@@ -4,6 +4,8 @@ import copy
 import datetime
 import glob
 
+from utils import group_manager
+
 from utils import js_constants as js_, md_constants as md_, helper_functions as help, image_tag_tools
 
 
@@ -71,6 +73,9 @@ class Gallery_tab:
         # stores the currently displayed gallery image paths to avoid passing
         # filepaths through gradio inputs
         self.gallery_state = gr.State([])
+
+        # mapping of group name -> list of [ext, img_id]
+        self.groups_state = gr.State({})
 
         # buffers holding tags transferred/removed during compare operations
         self.transfer_buffer = []  # tags to add when applying to other images
@@ -3482,6 +3487,17 @@ class Gallery_tab:
                 gallery_comp = gr.Gallery(visible=False, elem_id="gallery_id", object_fit="contain", interactive=True, columns=3, height=1356,
                          elem_classes="custom-gallery")
 
+                with gr.Accordion("Groups", open=False):
+                    groups_dropdown = gr.Dropdown(label="Saved Groups", choices=[], multiselect=True)
+                    group_name_text = gr.Textbox(label="Group Name", lines=1)
+                    with gr.Row():
+                        save_group_button = gr.Button(value="Save Group", variant='primary')
+                        load_group_button = gr.Button(value="Load Group", variant='secondary')
+                        delete_group_button = gr.Button(value="Delete Group", variant='stop')
+                    with gr.Row():
+                        rename_group_button = gr.Button(value="Rename Group")
+                        duplicate_group_button = gr.Button(value="Duplicate Group")
+
         self.refresh_aspect_btn = refresh_aspect_btn
         self.download_folder_type = download_folder_type
         self.img_id_textbox = img_id_textbox
@@ -3552,6 +3568,13 @@ class Gallery_tab:
         self.prepend_option = prepend_option
         self.prepend_now_button = prepend_now_button
         self.total_image_counter = total_image_counter
+        self.groups_dropdown = groups_dropdown
+        self.group_name_text = group_name_text
+        self.save_group_button = save_group_button
+        self.load_group_button = load_group_button
+        self.delete_group_button = delete_group_button
+        self.rename_group_button = rename_group_button
+        self.duplicate_group_button = duplicate_group_button
 
         return [
                 self.refresh_aspect_btn,
@@ -3624,7 +3647,14 @@ class Gallery_tab:
                 self.prepend_option,
                 self.prepend_now_button,
                 self.total_image_counter,
-                self.gallery_state
+                self.gallery_state,
+                self.groups_dropdown,
+                self.group_name_text,
+                self.save_group_button,
+                self.load_group_button,
+                self.delete_group_button,
+                self.rename_group_button,
+                self.duplicate_group_button
                 ]
 
     def get_event_listeners(self):
@@ -4085,3 +4115,75 @@ class Gallery_tab:
             inputs=[self.keyword_search_text, self.prepend_text, self.prepend_option, self.apply_to_all_type_select_checkboxgroup],
             outputs=[]
         )
+        self.save_group_button.click(
+            fn=self.save_group,
+            inputs=[self.group_name_text, self.groups_state, self.only_selected_state_object],
+            outputs=[self.groups_state, self.groups_dropdown, self.group_name_text]
+        )
+        self.delete_group_button.click(
+            fn=self.delete_group,
+            inputs=[self.groups_state, self.groups_dropdown],
+            outputs=[self.groups_state, self.groups_dropdown]
+        )
+        self.load_group_button.click(
+            fn=self.load_group,
+            inputs=[self.gallery_state, self.groups_state, self.groups_dropdown],
+            outputs=[self.images_selected_state, self.only_selected_state_object]
+        ).then(
+            None,
+            inputs=[self.images_selected_state, self.multi_select_ckbx_state],
+            outputs=None,
+            js=js_.js_do_everything
+        )
+        self.rename_group_button.click(
+            fn=self.rename_group,
+            inputs=[self.groups_state, self.groups_dropdown, self.group_name_text],
+            outputs=[self.groups_state, self.groups_dropdown, self.group_name_text]
+        )
+        self.duplicate_group_button.click(
+            fn=self.duplicate_group,
+            inputs=[self.groups_state, self.groups_dropdown, self.group_name_text],
+            outputs=[self.groups_state, self.groups_dropdown, self.group_name_text]
+        )
+ 
+
+    def save_group(self, name, groups_state, mapping):
+        groups = group_manager.save_group(groups_state or {}, name, mapping.values())
+        self.groups_state.value = groups
+        return groups, gr.update(choices=list(groups.keys())), gr.update(value="")
+
+    def delete_group(self, groups_state, group_names):
+        groups = group_manager.delete_groups(groups_state or {}, group_names)
+        self.groups_state.value = groups
+        return groups, gr.update(choices=list(groups.keys()))
+
+    def rename_group(self, groups_state, group_names, new_name):
+        if not group_names:
+            return groups_state, gr.update(choices=list((groups_state or {}).keys())), gr.update()
+        groups = group_manager.rename_group(groups_state or {}, group_names[0], new_name)
+        self.groups_state.value = groups
+        return groups, gr.update(choices=list(groups.keys()), value=new_name if new_name in groups else None), gr.update(value="")
+
+    def duplicate_group(self, groups_state, group_names, new_name):
+        if not group_names:
+            return groups_state, gr.update(choices=list((groups_state or {}).keys())), gr.update()
+        groups = group_manager.duplicate_group(groups_state or {}, group_names[0], new_name)
+        self.groups_state.value = groups
+        return groups, gr.update(choices=list(groups.keys()), value=new_name if new_name in groups else None), gr.update(value="")
+
+    def load_group(self, gallery_images, groups_state, group_names):
+        targets = group_manager.load_groups(groups_state or {}, group_names)
+        indices = []
+        mapping = {}
+        for idx, img in enumerate(gallery_images):
+            path = img[0] if isinstance(img, (list, tuple)) else img
+            ext, img_id = self.extract_name_and_extention(path)
+            for t_ext, t_id in targets:
+                if ext == t_ext and img_id == t_id:
+                    if idx not in indices:
+                        indices.append(idx)
+                        mapping[idx] = [ext, img_id]
+        self._update_search_from_mapping(mapping)
+        self.images_selected_state.value = indices
+        self.only_selected_state_object.value = mapping
+        return indices, mapping

--- a/tests/test_group_manager.py
+++ b/tests/test_group_manager.py
@@ -1,0 +1,24 @@
+import utils.group_manager as gm
+
+
+def test_save_and_load():
+    groups = {}
+    items = [["png", "a"], ["jpg", "b"]]
+    groups = gm.save_group(groups, "grp1", items)
+    assert "grp1" in groups
+    loaded = gm.load_groups(groups, ["grp1"])
+    assert sorted(loaded) == sorted(items)
+
+
+def test_delete_group():
+    groups = gm.save_group({}, "grp1", [["png", "a"]])
+    groups = gm.delete_groups(groups, ["grp1"])
+    assert groups == {}
+
+
+def test_rename_duplicate():
+    groups = gm.save_group({}, "g1", [["png", "a"]])
+    groups = gm.rename_group(groups, "g1", "g2")
+    assert "g2" in groups and "g1" not in groups
+    groups = gm.duplicate_group(groups, "g2", "g3")
+    assert groups["g2"] == groups["g3"]

--- a/utils/group_manager.py
+++ b/utils/group_manager.py
@@ -1,0 +1,60 @@
+"""Utility functions for managing image selection groups."""
+
+from typing import Dict, Iterable, List
+
+Group = List[List[str]]  # [[ext, img_id], ...]
+
+
+def _unique_items(items: Iterable[Iterable[str]]) -> Group:
+    seen = set()
+    unique: Group = []
+    for item in items:
+        tup = tuple(item)
+        if tup not in seen:
+            seen.add(tup)
+            unique.append(list(tup))
+    return unique
+
+
+def save_group(groups: Dict[str, Group], name: str, items: Iterable[Iterable[str]]) -> Dict[str, Group]:
+    """Save a group of items under a given name."""
+    if not name:
+        return groups
+    groups = groups.copy()
+    groups[name] = _unique_items(items)
+    return groups
+
+
+def delete_groups(groups: Dict[str, Group], names: Iterable[str]) -> Dict[str, Group]:
+    """Delete groups by name."""
+    groups = groups.copy()
+    for n in names:
+        groups.pop(n, None)
+    return groups
+
+
+def rename_group(groups: Dict[str, Group], old: str, new: str) -> Dict[str, Group]:
+    """Rename an existing group."""
+    if old not in groups or not new:
+        return groups
+    groups = groups.copy()
+    groups[new] = groups.pop(old)
+    return groups
+
+
+def duplicate_group(groups: Dict[str, Group], source: str, new: str) -> Dict[str, Group]:
+    """Create a new group from an existing one."""
+    if source not in groups or not new:
+        return groups
+    groups = groups.copy()
+    groups[new] = groups[source].copy()
+    return groups
+
+
+def load_groups(groups: Dict[str, Group], names: Iterable[str]) -> Group:
+    """Return combined unique items from the specified groups."""
+    items: Group = []
+    for n in names:
+        items.extend(groups.get(n, []))
+    return _unique_items(items)
+


### PR DESCRIPTION
## Summary
- add new `group_manager` utility module for saving/loading groups
- extend `Gallery_tab` with group-related UI elements and handlers
- track groups in `Gallery_tab` state
- add tests for group manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68685ed0099c83218a4b9e251501a0db