### PR TITLE
Fix group loading using unique image paths

### DIFF
--- a/UI_tabs/gallery_tab.py
+++ b/UI_tabs/gallery_tab.py
@@ -4,6 +4,8 @@ import copy
 import datetime
 import glob
 
+from utils import group_manager
+
 from utils import js_constants as js_, md_constants as md_, helper_functions as help, image_tag_tools
 
 
@@ -71,6 +73,10 @@ class Gallery_tab:
         # stores the currently displayed gallery image paths to avoid passing
         # filepaths through gradio inputs
         self.gallery_state = gr.State([])
+
+        # mapping of group name -> list of [ext, img_id]
+        self.groups_config_path = os.path.join(self.cwd, "groups.json")
+        self.groups_state = gr.State(group_manager.load_groups_file(self.groups_config_path))
 
         # buffers holding tags transferred/removed during compare operations
         self.transfer_buffer = []  # tags to add when applying to other images
@@ -622,6 +628,10 @@ class Gallery_tab:
             self.gallery_state.value = images
         except Exception:
             pass
+        # clear previous selections when performing a new search
+        self.images_selected_state.value = []
+        self.only_selected_state_object.value = {}
+        self._debug_selection([], {})
         count = self.get_total_image_count()
         return gr.update(value=images, visible=True), gr.update(value=f"Total Images: {count}")
 
@@ -1608,6 +1618,7 @@ class Gallery_tab:
     def _debug_selection(self, images_selected_state, mapping):
         help.verbose_print(f"images_selected_states:\t{images_selected_state}")
         help.verbose_print(f"only_selected_state_object:\t{mapping}")
+        help.verbose_print(f"number_selected:\t{len(images_selected_state)}")
 
     def select_all(self, gallery_images):
         """Return indices of all images for selection."""
@@ -2949,6 +2960,10 @@ class Gallery_tab:
             self.gallery_state.value = images
         except Exception:
             pass
+        # reset any previous selections on reload
+        self.images_selected_state.value = []
+        self.only_selected_state_object.value = {}
+        self._debug_selection([], {})
         count = self.get_total_image_count()
         return gr.update(value=images, visible=True), gr.update(value=f"Total Images: {count}")
 
@@ -3335,6 +3350,19 @@ class Gallery_tab:
                                   "Select All", "Clear All", "Invert All"]
 
             gr.Markdown(md_.preview)
+            with gr.Accordion("Groups", open=False):
+                groups_dropdown = gr.Dropdown(label="Saved Groups", choices=list(self.groups_state.value.keys()), multiselect=True)
+                group_name_text = gr.Textbox(label="Group Name", lines=1)
+                with gr.Row():
+                    save_group_button = gr.Button(value="Save Group", variant='primary')
+                    load_group_button = gr.Button(value="Load Group", variant='secondary')
+                    delete_group_button = gr.Button(value="Delete Group", variant='stop')
+                with gr.Row():
+                    rename_group_button = gr.Button(value="Rename Group")
+                    duplicate_group_button = gr.Button(value="Duplicate Group")
+                with gr.Row():
+                    save_groups_cfg_button = gr.Button(value="Save Config")
+                    load_groups_cfg_button = gr.Button(value="Load Config")
             with gr.Row():
                 with gr.Column():
                     with gr.Row():
@@ -3482,6 +3510,7 @@ class Gallery_tab:
                 gallery_comp = gr.Gallery(visible=False, elem_id="gallery_id", object_fit="contain", interactive=True, columns=3, height=1356,
                          elem_classes="custom-gallery")
 
+
         self.refresh_aspect_btn = refresh_aspect_btn
         self.download_folder_type = download_folder_type
         self.img_id_textbox = img_id_textbox
@@ -3552,6 +3581,15 @@ class Gallery_tab:
         self.prepend_option = prepend_option
         self.prepend_now_button = prepend_now_button
         self.total_image_counter = total_image_counter
+        self.groups_dropdown = groups_dropdown
+        self.group_name_text = group_name_text
+        self.save_group_button = save_group_button
+        self.load_group_button = load_group_button
+        self.delete_group_button = delete_group_button
+        self.rename_group_button = rename_group_button
+        self.duplicate_group_button = duplicate_group_button
+        self.save_groups_cfg_button = save_groups_cfg_button
+        self.load_groups_cfg_button = load_groups_cfg_button
 
         return [
                 self.refresh_aspect_btn,
@@ -3624,7 +3662,16 @@ class Gallery_tab:
                 self.prepend_option,
                 self.prepend_now_button,
                 self.total_image_counter,
-                self.gallery_state
+                self.gallery_state,
+                self.groups_dropdown,
+                self.group_name_text,
+                self.save_group_button,
+                self.load_group_button,
+                self.delete_group_button,
+                self.rename_group_button,
+                self.duplicate_group_button,
+                self.save_groups_cfg_button,
+                self.load_groups_cfg_button
                 ]
 
     def get_event_listeners(self):
@@ -4085,3 +4132,97 @@ class Gallery_tab:
             inputs=[self.keyword_search_text, self.prepend_text, self.prepend_option, self.apply_to_all_type_select_checkboxgroup],
             outputs=[]
         )
+        self.save_group_button.click(
+            fn=self.save_group,
+            inputs=[self.group_name_text, self.groups_state, self.gallery_state, self.images_selected_state],
+            outputs=[self.groups_state, self.groups_dropdown, self.group_name_text]
+        )
+        self.delete_group_button.click(
+            fn=self.delete_group,
+            inputs=[self.groups_state, self.groups_dropdown],
+            outputs=[self.groups_state, self.groups_dropdown]
+        )
+        self.load_group_button.click(
+            fn=self.load_group,
+            inputs=[self.gallery_state, self.groups_state, self.groups_dropdown],
+            outputs=[self.images_selected_state, self.only_selected_state_object]
+        ).then(
+            None,
+            inputs=[self.images_selected_state, self.multi_select_ckbx_state],
+            outputs=None,
+            js=js_.js_do_everything
+        )
+        self.rename_group_button.click(
+            fn=self.rename_group,
+            inputs=[self.groups_state, self.groups_dropdown, self.group_name_text],
+            outputs=[self.groups_state, self.groups_dropdown, self.group_name_text]
+        )
+        self.duplicate_group_button.click(
+            fn=self.duplicate_group,
+            inputs=[self.groups_state, self.groups_dropdown, self.group_name_text],
+            outputs=[self.groups_state, self.groups_dropdown, self.group_name_text]
+        )
+        self.save_groups_cfg_button.click(
+            fn=self.save_groups_config,
+            inputs=[self.groups_state],
+            outputs=[]
+        )
+        self.load_groups_cfg_button.click(
+            fn=self.load_groups_config,
+            inputs=[],
+            outputs=[self.groups_state, self.groups_dropdown]
+        )
+ 
+
+    def save_group(self, name, groups_state, gallery_images, indices):
+        paths = []
+        for idx in indices:
+            if 0 <= idx < len(gallery_images):
+                path = gallery_images[idx][0] if isinstance(gallery_images[idx], (list, tuple)) else gallery_images[idx]
+                paths.append(path)
+        groups = group_manager.save_group(groups_state or {}, name, paths)
+        self.groups_state.value = groups
+        return groups, gr.update(choices=list(groups.keys())), gr.update(value="")
+
+    def delete_group(self, groups_state, group_names):
+        groups = group_manager.delete_groups(groups_state or {}, group_names)
+        self.groups_state.value = groups
+        return groups, gr.update(choices=list(groups.keys()))
+
+    def rename_group(self, groups_state, group_names, new_name):
+        if not group_names:
+            return groups_state, gr.update(choices=list((groups_state or {}).keys())), gr.update()
+        groups = group_manager.rename_group(groups_state or {}, group_names[0], new_name)
+        self.groups_state.value = groups
+        return groups, gr.update(choices=list(groups.keys()), value=new_name if new_name in groups else None), gr.update(value="")
+
+    def duplicate_group(self, groups_state, group_names, new_name):
+        if not group_names:
+            return groups_state, gr.update(choices=list((groups_state or {}).keys())), gr.update()
+        groups = group_manager.duplicate_group(groups_state or {}, group_names[0], new_name)
+        self.groups_state.value = groups
+        return groups, gr.update(choices=list(groups.keys()), value=new_name if new_name in groups else None), gr.update(value="")
+
+    def load_group(self, gallery_images, groups_state, group_names):
+        targets = set(group_manager.load_groups(groups_state or {}, group_names))
+        indices = []
+        mapping = {}
+        for idx, img in enumerate(gallery_images):
+            path = img[0] if isinstance(img, (list, tuple)) else img
+            if path in targets:
+                ext, img_id = self.extract_name_and_extention(path)
+                indices.append(idx)
+                mapping[idx] = [ext, img_id]
+        self._update_search_from_mapping(mapping)
+        self.images_selected_state.value = indices
+        self.only_selected_state_object.value = mapping
+        self._debug_selection(indices, mapping)
+        return indices, mapping
+
+    def save_groups_config(self, groups_state):
+        group_manager.save_groups_file(groups_state or {}, self.groups_config_path)
+
+    def load_groups_config(self):
+        groups = group_manager.load_groups_file(self.groups_config_path)
+        self.groups_state.value = groups
+        return groups, gr.update(choices=list(groups.keys()))

--- a/tests/test_group_manager.py
+++ b/tests/test_group_manager.py
@@ -1,0 +1,32 @@
+import utils.group_manager as gm
+
+
+def test_save_and_load():
+    groups = {}
+    items = ["/path/a.png", "/path/b.jpg"]
+    groups = gm.save_group(groups, "grp1", items)
+    assert "grp1" in groups
+    loaded = gm.load_groups(groups, ["grp1"])
+    assert sorted(loaded) == sorted(items)
+
+
+def test_delete_group():
+    groups = gm.save_group({}, "grp1", ["/tmp/a.png"])
+    groups = gm.delete_groups(groups, ["grp1"])
+    assert groups == {}
+
+
+def test_rename_duplicate():
+    groups = gm.save_group({}, "g1", ["/tmp/a.png"])
+    groups = gm.rename_group(groups, "g1", "g2")
+    assert "g2" in groups and "g1" not in groups
+    groups = gm.duplicate_group(groups, "g2", "g3")
+    assert groups["g2"] == groups["g3"]
+
+
+def test_file_roundtrip(tmp_path):
+    groups = gm.save_group({}, "grp", ["a.png", "b.jpg"])
+    fp = tmp_path / "groups.json"
+    gm.save_groups_file(groups, fp)
+    loaded = gm.load_groups_file(fp)
+    assert loaded == groups

--- a/utils/group_manager.py
+++ b/utils/group_manager.py
@@ -1,0 +1,88 @@
+"""Utility functions for managing image selection groups."""
+
+import json
+import os
+from typing import Dict, Iterable, List
+
+# groups map a name to a list of image paths
+Group = List[str]
+
+
+def _unique_items(items: Iterable[str]) -> Group:
+    """Return items with duplicates removed while preserving order."""
+    seen = set()
+    unique: Group = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            unique.append(item)
+    return unique
+
+
+def save_group(groups: Dict[str, Group], name: str, items: Iterable[str]) -> Dict[str, Group]:
+    """Save a group of items under a given name."""
+    if not name:
+        return groups
+    groups = groups.copy()
+    groups[name] = _unique_items(items)
+    return groups
+
+
+def delete_groups(groups: Dict[str, Group], names: Iterable[str]) -> Dict[str, Group]:
+    """Delete groups by name."""
+    groups = groups.copy()
+    for n in names:
+        groups.pop(n, None)
+    return groups
+
+
+def rename_group(groups: Dict[str, Group], old: str, new: str) -> Dict[str, Group]:
+    """Rename an existing group."""
+    if old not in groups or not new:
+        return groups
+    groups = groups.copy()
+    groups[new] = groups.pop(old)
+    return groups
+
+
+def duplicate_group(groups: Dict[str, Group], source: str, new: str) -> Dict[str, Group]:
+    """Create a new group from an existing one."""
+    if source not in groups or not new:
+        return groups
+    groups = groups.copy()
+    groups[new] = groups[source].copy()
+    return groups
+
+
+def load_groups(groups: Dict[str, Group], names: Iterable[str]) -> Group:
+    """Return combined unique items from the specified groups."""
+    items: Group = []
+    for n in names:
+        items.extend(groups.get(n, []))
+    return _unique_items(items)
+
+
+def save_groups_file(groups: Dict[str, Group], path: str) -> None:
+    """Write groups dictionary to ``path`` as JSON."""
+    dir_name = os.path.dirname(path)
+    if dir_name:
+        os.makedirs(dir_name, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(groups, f, indent=2)
+
+
+def load_groups_file(path: str) -> Dict[str, Group]:
+    """Load groups dictionary from ``path`` if it exists."""
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except json.JSONDecodeError:
+        return {}
+    groups: Dict[str, Group] = {}
+    for k, v in data.items():
+        if isinstance(v, list):
+            groups[k] = [str(item) for item in v]
+    return groups
+


### PR DESCRIPTION
## Summary
- manage groups by storing image paths instead of id/ext pairs
- update group save/load handlers to work with new path-based groups
- adjust group manager tests for path entries
- clear selection state when searching or reloading
- print selections after loading a group
- move the Groups accordion below the gallery markdown

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68685ed0099c83218a4b9e251501a0db