### PR TITLE
Move dataset gallery controls to top

### DIFF
--- a/UI_tabs/custom_dataset_tab.py
+++ b/UI_tabs/custom_dataset_tab.py
@@ -879,6 +879,14 @@ class Custom_dataset_tab:
     def render_tab(self):
         with gr.Tab("Add Custom Dataset"):
             gr.Markdown(md_.custom)
+            with gr.Row():
+                dataset_gallery_path_textbox = gr.Textbox(label="Dataset Folder Path",
+                                                          info="Folder with images and tag txt files",
+                                                          interactive=True,
+                                                          elem_id="dataset_gallery_path_textbox")
+                load_dataset_gallery_button = gr.Button(value="Load Dataset to Gallery",
+                                                      variant='secondary',
+                                                      elem_id="load_dataset_gallery_button")
             image_modes = ['Single', 'Batch']
             self.auto_tag_models.append("PNG Info")
 
@@ -992,11 +1000,6 @@ class Custom_dataset_tab:
                             image_with_tag_path_textbox = gr.Textbox(label="Path to Image/Video Folder",
                                                                      info="Folder should contain both (tag/s & image/s) if no video",
                                                                      interactive=True)
-                        with gr.Row():
-                            dataset_gallery_path_textbox = gr.Textbox(label="Dataset Folder Path",
-                                                                      info="Folder with images and tag txt files",
-                                                                      interactive=True)
-                            load_dataset_gallery_button = gr.Button(value="Load Dataset to Gallery", variant='secondary')
                         with gr.Row():
                             with gr.Column(min_width=50, scale=1):
                                 copy_mode_ckbx = gr.Checkbox(label="Copy", info="Copy To Tag Editor")

--- a/utils/css_constants.py
+++ b/utils/css_constants.py
@@ -71,3 +71,12 @@ tag_checkbox_color_css = """
 .lore-checkbox label { color: black !important; }
 .copyright-checkbox label { color: violet !important; }
 """
+
+dataset_gallery_css = """
+#dataset_gallery_path_textbox label {
+    color: cyan !important;
+}
+#load_dataset_gallery_button {
+    background-color: red !important;
+}
+"""

--- a/webui.py
+++ b/webui.py
@@ -23,7 +23,7 @@ def build_ui(enable_tag_suggestions=True):
 
     with gr.Blocks(css=f"{css_.preview_hide_rule} {css_.refresh_aspect_btn_rule} {css_.trim_row_length} {css_.trim_markdown_length} "
                        f"{css_.thumbnail_colored_border_css} {css_.refresh_models_btn_rule}"
-                       f"{css_.green_button_css} {css_.red_button_css} {css_.gallery_fix_height} {css_.tag_checkbox_color_css}") as demo:
+                       f"{css_.green_button_css} {css_.red_button_css} {css_.gallery_fix_height} {css_.tag_checkbox_color_css} {css_.dataset_gallery_css}") as demo:
 
         # set local path
         cwd = os.getcwd()


### PR DESCRIPTION
## Summary
- move dataset gallery path textbox and button to top of the Add Custom Dataset tab
- style dataset gallery textbox label and button with new CSS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a9462e36083218d7bb232433f1382