### PR TITLE
Fix orjson missing error

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,6 +27,7 @@ dependencies:
     - huggingface_hub
     - beautifulsoup4
     - pandas
+    - orjson
     - onnxruntime
     - onnxruntime-gpu
     - piexif

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ gradio
 beautifulsoup4
 Pillow
 pandas
+orjson
 onnxruntime
 torch
 onnxruntime-gpu


### PR DESCRIPTION
## Summary
- add `orjson` to dependencies for Conda and pip

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686abcf905988321a4852f8e3ec049f6