### PR TITLE
Separate dataset loading and model features

### DIFF
--- a/UI_tabs/dataset_loader_tab.py
+++ b/UI_tabs/dataset_loader_tab.py
@@ -1,0 +1,36 @@
+import gradio as gr
+from utils import md_constants as md_
+
+class Dataset_loader_tab:
+    def __init__(self, gallery_tab_manager):
+        self.gallery_tab_manager = gallery_tab_manager
+
+    def render_tab(self):
+        with gr.Tab("Add Custom Dataset"):
+            gr.Markdown(md_.custom)
+            with gr.Row():
+                dataset_gallery_path_textbox = gr.Textbox(
+                    label="Dataset Folder Path",
+                    info="Folder with images and tag txt files",
+                    interactive=True,
+                    elem_id="dataset_gallery_path_textbox",
+                )
+                load_dataset_gallery_button = gr.Button(
+                    value="Load Dataset to Gallery",
+                    variant="secondary",
+                    elem_id="load_dataset_gallery_button",
+                )
+        self.dataset_gallery_path_textbox = dataset_gallery_path_textbox
+        self.load_dataset_gallery_button = load_dataset_gallery_button
+        return [self.dataset_gallery_path_textbox, self.load_dataset_gallery_button]
+
+    def get_event_listeners(self):
+        self.load_dataset_gallery_button.click(
+            fn=self.gallery_tab_manager.reset_gallery_component_only,
+            inputs=None,
+            outputs=[self.gallery_tab_manager.gallery_comp, self.gallery_tab_manager.total_image_counter],
+        ).then(
+            fn=self.gallery_tab_manager.load_external_dataset,
+            inputs=[self.dataset_gallery_path_textbox],
+            outputs=[self.gallery_tab_manager.gallery_comp, self.gallery_tab_manager.total_image_counter],
+        )

--- a/UI_tabs/image_augmentation_tab.py
+++ b/UI_tabs/image_augmentation_tab.py
@@ -1,0 +1,76 @@
+import gradio as gr
+
+class Image_augmentation_tab:
+    def __init__(self, logic_manager):
+        self.logic = logic_manager
+
+    def render_tab(self):
+        with gr.Tab("Image Augmentation"):
+            operation_choices = ["Crop", "Zoom", "Resize", "Rotate", "Scale", "Translation",
+                                "Brightness", "Contrast", "Saturation", "Noise", "Shear", "Horizontal Flip", "Vertical Flip"]
+            operations_dropdown = gr.Dropdown(choices=operation_choices, multiselect=True, label="Preprocess Options", interactive=True, value=[])
+            with gr.Row():
+                landscape_crop_dropdown = gr.Dropdown(choices=['left', 'mid', 'right', None], label="Landscape Crop", info="Mandatory", visible=False)
+                portrait_crop_dropdown = gr.Dropdown(choices=['top', 'mid', 'bottom', None], label="Portrait Crop", info="Mandatory", visible=False)
+            zoom_slider = gr.Slider(minimum=0.5, maximum=3.0, value=1.0, step=0.1, label="Zoom Value", visible=False)
+            rotate_slider = gr.Slider(minimum=-180, maximum=180, step=1, value=0, visible=False, label="Rotate Value")
+            scale_slider = gr.Slider(minimum=0.5, maximum=2, step=0.05, value=1, visible=False, label="Scale Value")
+            dx_slider = gr.Slider(minimum=-100, maximum=100, step=1, value=0, visible=False, label="Translation-X Value")
+            dy_slider = gr.Slider(minimum=-100, maximum=100, step=1, value=0, visible=False, label="Translation-Y Value")
+            brightness_slider = gr.Slider(minimum=0.5, maximum=2, step=0.05, value=1, visible=False, label="Brightness Value")
+            contrast_slider = gr.Slider(minimum=0.5, maximum=2, step=0.05, value=1, visible=False, label="Contrast Value")
+            saturation_slider = gr.Slider(minimum=0.5, maximum=2, step=0.05, value=1, visible=False, label="Saturation Value")
+            noise_slider = gr.Slider(minimum=0, maximum=100, step=1, value=0, visible=False, label="Noise Value")
+            shear_slider = gr.Slider(minimum=-0.5, maximum=0.5, step=0.05, value=0, visible=False, label="Shear Value")
+        # expose components on logic manager
+        self.logic.operations_dropdown = operations_dropdown
+        self.logic.landscape_crop_dropdown = landscape_crop_dropdown
+        self.logic.portrait_crop_dropdown = portrait_crop_dropdown
+        self.logic.zoom_slider = zoom_slider
+        self.logic.rotate_slider = rotate_slider
+        self.logic.scale_slider = scale_slider
+        self.logic.dx_slider = dx_slider
+        self.logic.dy_slider = dy_slider
+        self.logic.brightness_slider = brightness_slider
+        self.logic.contrast_slider = contrast_slider
+        self.logic.saturation_slider = saturation_slider
+        self.logic.noise_slider = noise_slider
+        self.logic.shear_slider = shear_slider
+
+        self.operations_dropdown = operations_dropdown
+        self.landscape_crop_dropdown = landscape_crop_dropdown
+        self.portrait_crop_dropdown = portrait_crop_dropdown
+        self.zoom_slider = zoom_slider
+        self.rotate_slider = rotate_slider
+        self.scale_slider = scale_slider
+        self.dx_slider = dx_slider
+        self.dy_slider = dy_slider
+        self.brightness_slider = brightness_slider
+        self.contrast_slider = contrast_slider
+        self.saturation_slider = saturation_slider
+        self.noise_slider = noise_slider
+        self.shear_slider = shear_slider
+
+        return [operations_dropdown]
+
+    def get_event_listeners(self):
+        self.operations_dropdown.change(
+            fn=self.logic.make_menus_visible,
+            inputs=[self.operations_dropdown],
+            outputs=[self.landscape_crop_dropdown, self.portrait_crop_dropdown, self.zoom_slider, self.rotate_slider,
+                     self.scale_slider, self.dx_slider, self.dy_slider, self.brightness_slider, self.contrast_slider,
+                     self.saturation_slider, self.noise_slider, self.shear_slider],
+        )
+        self.zoom_slider.change(fn=self.logic.set_zoom_slider, inputs=[self.zoom_slider], outputs=[])
+        self.rotate_slider.change(fn=self.logic.set_rotate_slider, inputs=[self.rotate_slider], outputs=[])
+        self.scale_slider.change(fn=self.logic.set_scale_slider, inputs=[self.scale_slider], outputs=[])
+        self.dx_slider.change(fn=self.logic.set_dx_slider, inputs=[self.dx_slider], outputs=[])
+        self.dy_slider.change(fn=self.logic.set_dy_slider, inputs=[self.dy_slider], outputs=[])
+        self.brightness_slider.change(fn=self.logic.set_brightness_slider, inputs=[self.brightness_slider], outputs=[])
+        self.contrast_slider.change(fn=self.logic.set_contrast_slider, inputs=[self.contrast_slider], outputs=[])
+        self.saturation_slider.change(fn=self.logic.set_saturation_slider, inputs=[self.saturation_slider], outputs=[])
+        self.noise_slider.change(fn=self.logic.set_noise_slider, inputs=[self.noise_slider], outputs=[])
+        self.shear_slider.change(fn=self.logic.set_shear_slider, inputs=[self.shear_slider], outputs=[])
+        self.landscape_crop_dropdown.select(fn=self.logic.set_landscape_square_crop, inputs=[self.landscape_crop_dropdown], outputs=[])
+        self.portrait_crop_dropdown.select(fn=self.logic.set_portrait_square_crop, inputs=[self.portrait_crop_dropdown], outputs=[])
+

--- a/UI_tabs/model_inference_tab.py
+++ b/UI_tabs/model_inference_tab.py
@@ -1,0 +1,90 @@
+import gradio as gr
+
+class Model_inference_tab:
+    def __init__(self, logic_manager):
+        self.logic = logic_manager
+
+    def render_tab(self):
+        with gr.Tab("Model Inference"):
+            with gr.Row():
+                file_upload_button_single = gr.File(label="Single Image Mode", file_count="single", interactive=True, file_types=["image"], type="filepath")
+                file_upload_button_batch = gr.File(label="Batch Image Mode", file_count="directory", interactive=True, type="filepath")
+            with gr.Row():
+                gpu_ckbx = gr.Checkbox(label="GPU", info="Use GPU", value=False)
+                refresh_models_btn = gr.Button(value="\U0001f504", variant="secondary")
+                model_choice_dropdown = gr.Dropdown(choices=self.logic.auto_tag_models, label="Model Selection")
+            confidence_threshold_slider = gr.Slider(minimum=0, maximum=100, step=1, label="Confidence Threshold", value=75)
+            interrogate_button = gr.Button(value="Interrogate", variant='primary')
+            with gr.Row():
+                image_confidence_values = gr.Label(label="Tag/s Confidence/s", visible=True, value={})
+                image_generated_tags = gr.CheckboxGroup(label="Generated Tag/s", choices=[], visible=True, interactive=True)
+            image_preview_pil = gr.Image(label="Image Preview", interactive=False, visible=True, type="pil", height=420)
+        # expose components on logic manager for other tabs
+        self.logic.file_upload_button_single = file_upload_button_single
+        self.logic.file_upload_button_batch = file_upload_button_batch
+        self.logic.gpu_ckbx = gpu_ckbx
+        self.logic.refresh_models_btn = refresh_models_btn
+        self.logic.model_choice_dropdown = model_choice_dropdown
+        self.logic.confidence_threshold_slider = confidence_threshold_slider
+        self.logic.interrogate_button = interrogate_button
+        self.logic.image_confidence_values = image_confidence_values
+        self.logic.image_generated_tags = image_generated_tags
+        self.logic.image_preview_pil = image_preview_pil
+        self.logic.gallery_images_batch = None
+        self.logic.include_invalid_tags_ckbx = True
+
+        self.file_upload_button_single = file_upload_button_single
+        self.file_upload_button_batch = file_upload_button_batch
+        self.gpu_ckbx = gpu_ckbx
+        self.refresh_models_btn = refresh_models_btn
+        self.model_choice_dropdown = model_choice_dropdown
+        self.confidence_threshold_slider = confidence_threshold_slider
+        self.interrogate_button = interrogate_button
+        self.image_confidence_values = image_confidence_values
+        self.image_generated_tags = image_generated_tags
+        self.image_preview_pil = image_preview_pil
+        return [
+            file_upload_button_single,
+            file_upload_button_batch,
+            gpu_ckbx,
+            refresh_models_btn,
+            model_choice_dropdown,
+            confidence_threshold_slider,
+            interrogate_button,
+            image_confidence_values,
+            image_generated_tags,
+            image_preview_pil,
+        ]
+
+    def get_event_listeners(self):
+        self.refresh_models_btn.click(
+            fn=self.logic.refresh_model_list,
+            inputs=[],
+            outputs=[self.model_choice_dropdown],
+        )
+        self.model_choice_dropdown.select(
+            fn=self.logic.load_model,
+            inputs=[self.model_choice_dropdown, self.gpu_ckbx],
+            outputs=[],
+        )
+        self.file_upload_button_single.upload(
+            fn=self.logic.load_images,
+            inputs=[self.file_upload_button_single, self.logic.image_mode_choice_state],
+            outputs=[self.logic.image_mode_choice_state],
+        )
+        self.file_upload_button_batch.upload(
+            fn=self.logic.load_images,
+            inputs=[self.file_upload_button_batch, self.logic.image_mode_choice_state],
+            outputs=[self.logic.image_mode_choice_state],
+        )
+        self.confidence_threshold_slider.change(
+            fn=self.logic.set_threshold,
+            inputs=[self.confidence_threshold_slider],
+            outputs=[self.image_confidence_values, self.image_generated_tags],
+        )
+        self.interrogate_button.click(
+            fn=self.logic.interrogate_images,
+            inputs=[self.logic.image_mode_choice_state, self.confidence_threshold_slider, None, False, None, self.logic.include_invalid_tags_ckbx],
+            outputs=[self.image_confidence_values, self.image_generated_tags, self.image_preview_pil, gr.State(None)],
+        )
+

--- a/webui.py
+++ b/webui.py
@@ -15,6 +15,9 @@ def build_ui(enable_tag_suggestions=True):
     from UI_tabs.stats_tab import Stats_tab
     from UI_tabs.extras_tab import Extras_tab
     from UI_tabs.custom_dataset_tab import Custom_dataset_tab
+    from UI_tabs.dataset_loader_tab import Dataset_loader_tab
+    from UI_tabs.model_inference_tab import Model_inference_tab
+    from UI_tabs.image_augmentation_tab import Image_augmentation_tab
     from UI_tabs.image_editor_tab import Image_editor_tab
     from UI_tabs.advanced_settings_tab import Advanced_settings_tab
     from UI_tabs.database_tab import Database_tab
@@ -235,6 +238,10 @@ def build_ui(enable_tag_suggestions=True):
             all_predicted_tags,
         )
 
+        dataset_loader_tab_manager = Dataset_loader_tab(gallery_tab_manager)
+        model_inference_tab_manager = Model_inference_tab(custom_dataset_tab_manager)
+        image_augmentation_tab_manager = Image_augmentation_tab(custom_dataset_tab_manager)
+
         image_editor_tab_manager = Image_editor_tab(
             gallery_tab_manager,
             download_tab_manager,
@@ -250,7 +257,9 @@ def build_ui(enable_tag_suggestions=True):
         merge_tab_manager = Merge_tab(db_manager)
 
         # render tabs in desired order
-        custom_dataset_tab_manager.render_tab()
+        dataset_loader_tab_manager.render_tab()
+        model_inference_tab_manager.render_tab()
+        image_augmentation_tab_manager.render_tab()
         gallery_tab_manager.render_tab()
         image_editor_tab_manager.render_tab()
         stats_tab_manager.render_tab()
@@ -290,7 +299,9 @@ def build_ui(enable_tag_suggestions=True):
         gallery_tab_manager.get_event_listeners()
         stats_tab_manager.get_event_listeners()
         extras_tab_manager.get_event_listeners()
-        custom_dataset_tab_manager.get_event_listeners()
+        dataset_loader_tab_manager.get_event_listeners()
+        model_inference_tab_manager.get_event_listeners()
+        image_augmentation_tab_manager.get_event_listeners()
         image_editor_tab_manager.get_event_listeners()
         database_tab_manager.get_event_listeners()
         import_tab_manager.get_event_listeners()


### PR DESCRIPTION
## Summary
- add a new `Dataset_loader_tab` for loading external datasets
- add `Model_inference_tab` with simple model interrogation UI
- add `Image_augmentation_tab` exposing preprocessing sliders
- integrate the new tabs into `webui.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c35f0f848832192ac620171c5cc28