### PR TITLE
fix: include invalid tag category

### DIFF
--- a/utils/features/image_boards/e6.json
+++ b/utils/features/image_boards/e6.json
@@ -14,6 +14,7 @@
         "artist",
         "character",
         "species",
+        "invalid",
         "general",
         "meta",
         "rating"


### PR DESCRIPTION
## Summary
- allow `invalid` in tag ordering by marking it a valid category

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68901aebc6b88321aed89bc7a5566c99